### PR TITLE
TArray Updates

### DIFF
--- a/src/Libtask.jl
+++ b/src/Libtask.jl
@@ -1,6 +1,6 @@
 module Libtask
 
-export consume, produce, TArray, get, tzeros, TRef
+export consume, produce, TArray, get, tzeros, tfill
 
 include("../deps/deps.jl"); check_deps();
 include("taskcopy.jl")

--- a/src/Libtask.jl
+++ b/src/Libtask.jl
@@ -1,6 +1,6 @@
 module Libtask
 
-export consume, produce, TArray, get, tzeros
+export consume, produce, TArray, get, tzeros, TRef
 
 include("../deps/deps.jl"); check_deps();
 include("taskcopy.jl")

--- a/src/tarray.jl
+++ b/src/tarray.jl
@@ -23,7 +23,7 @@ for i in 1:4 ta[i] = i end  # assign
 Array(ta)                   # convert to 4-element Array{Int64,1}: [1, 2, 3, 4]
 ```
 """
-struct TArray{T,N} <: DenseArray{T,N}
+struct TArray{T,N} <: AbstractArray{T,N}
   ref :: Symbol  # object_id
   TArray{T,N}() where {T,N} = new(gensym())
 end

--- a/src/tarray.jl
+++ b/src/tarray.jl
@@ -42,30 +42,27 @@ function TArray(T::Type, dim)
   res
 end
 
+'''
+Indexing Interface Implementation
+'''
 # pass through getindex and setindex!
 # duplicate TArray if task id does not match current_task
 function Base.getindex(S::TArray, i::Real)
-  t, d = task_local_storage(S.ref)
-  newd = d
-#   ct = current_task()
-#   if t != ct
-#     # println("[getindex]: $(S.ref ) copying data")
-#     newd = deepcopy(d)
-#     task_local_storage(S.ref, (ct, newd))
-#   end
-  getindex(newd, i)
+    t, d = task_local_storage(S.ref)
+    newd = d
+    getindex(newd, i)
 end
 
 function Base.setindex!(S::TArray, x, i::Real)
-  n, d = task_local_storage(S.ref)
-  cn   = n_copies()
-  newd = d
-  if cn > n
-    # println("[setindex!]: $(S.ref) copying data")
-    newd = deepcopy(d)
-    task_local_storage(S.ref, (cn, newd))
-  end
-  setindex!(newd, x, i)
+    n, d = task_local_storage(S.ref)
+    cn   = n_copies()
+    newd = d
+    if cn > n
+        # println("[setindex!]: $(S.ref) copying data")
+        newd = deepcopy(d)
+        task_local_storage(S.ref, (cn, newd))
+    end
+    setindex!(newd, x, i)
 end
 
 function Base.firstindex(S::TArray)

--- a/src/tarray.jl
+++ b/src/tarray.jl
@@ -68,6 +68,16 @@ function Base.setindex!(S::TArray, x, i::Real)
   setindex!(newd, x, i)
 end
 
+function Base.firstindex(S::TArray)
+    _, d = task_local_storage(S.ref)
+    firstindex(d)
+end
+
+function Base.lastindex(S::TArray)
+    _, d = task_local_storage(S.ref)
+    lastindex(d)
+end
+
 function Base.push!(S::TArray, x)
   n, d = task_local_storage(S.ref)
   cn   = n_copies()

--- a/src/tarray.jl
+++ b/src/tarray.jl
@@ -42,15 +42,12 @@ function TArray(T::Type, dim)
   res
 end
 
-'''
-Indexing Interface Implementation
-'''
-# pass through getindex and setindex!
-# duplicate TArray if task id does not match current_task
+#
+# Indexing Interface Implementation
+#
 function Base.getindex(S::TArray, i::Real)
     t, d = task_local_storage(S.ref)
-    newd = d
-    getindex(newd, i)
+    getindex(d, i)
 end
 
 function Base.setindex!(S::TArray, x, i::Real)
@@ -73,6 +70,14 @@ end
 function Base.lastindex(S::TArray)
     _, d = task_local_storage(S.ref)
     lastindex(d)
+end
+
+#
+# Iterator Interface Implementation
+#
+function Base.iterate(S::TArray, state=1)
+    _, d = task_local_storage(S.ref)
+    return iterate(d, state)
 end
 
 function Base.push!(S::TArray, x)

--- a/src/tarray.jl
+++ b/src/tarray.jl
@@ -124,6 +124,17 @@ Base.ndims(S::TArray) = Base.ndims(task_local_storage(S.ref)[2])
 # Base.get(t::Task, S::TArray) = (t.storage[S.ref][2])
 Base.get(S::TArray) = (current_task().storage[S.ref][2])
 
+#
+# Similarity implementation
+#
+function Base.eltype(S::TArray)
+    _, d = task_local_storage(S.ref)
+    return eltype(d)
+end
+
+Base.similar(S::TArray) = tzeros(eltype(S), size(S))
+Base.similar(S::TArray, ::Type{T}) where {T} = tzeros(T, size(S))
+Base.similar(S::TArray, dims::Dims) = tzeros(eltype(S), dims)
 
 ##########
 # tzeros #

--- a/test/tarray.jl
+++ b/test/tarray.jl
@@ -25,3 +25,4 @@ Base.@assert consume(a) == 4
 # Base.@assert TArray(Float64,  5)[1] != 0 REVIEW: can we remove this? (Kai)
 Base.@assert tzeros(Float64, 5)[1]==0
 Base.@assert tzeros(4)[1]==0
+Base.@assert tfill(5, 5)[1] == 5

--- a/test/tarray2.jl
+++ b/test/tarray2.jl
@@ -29,3 +29,6 @@ for i in 1:4 ta6[i] = i / 10 end
 @test Array(ta6) == [0.1, 0.2, 0.3, 0.4]
 
 ta7 = TArray{Int, 2}((2, 2));   # TODO: add test for use this multi-dim array
+
+ta8 = tfill(19, (5,5,5,5))
+@test ta8[1,1,1,1] == 19


### PR DESCRIPTION
This contains updates for the TArray type and related functions.

Highlights:
- Implements indexing interface
- Implements Iterators
- Added `similar` functions
- `TArray` is now a subtype of `AbstractArray`
- Added `display` function and a new field on the `TArray` which stores the original task to aid in printing

The `TRef` type which stores arbitrary content is outside of this request for now. I'm not quite happy yet with the implementation for the moment.

Please take a look and let me know if there's anything I've missed or additional features I can tack on here.