### PR TITLE
[WIP] TRef initial commit

### DIFF
--- a/src/Libtask.jl
+++ b/src/Libtask.jl
@@ -1,9 +1,10 @@
 module Libtask
 
-export consume, produce, TArray, get, tzeros, tfill
+export consume, produce, TArray, get, tzeros, tfill, TRef
 
 include("../deps/deps.jl"); check_deps();
 include("taskcopy.jl")
 include("tarray.jl")
+include("tref.jl")
 
 end

--- a/src/tarray.jl
+++ b/src/tarray.jl
@@ -31,7 +31,9 @@ end
 
 TArray{T,1}(d::Integer) where T = TArray(T,  d)
 TArray{T}(d::Integer...) where T = TArray(T, d)
+TArray{T}(UndefInitializer, d::Integer...) where T = TArray(T, d)
 TArray{T,N}(d::Integer...) where {T,N} = length(d)==N ? TArray(T,d) : error("Malformed dims")
+TArray{T,N}(UndefInitializer, d::Integer...) where {T,N} = length(d)==N ? TArray(T,d) : error("Malformed dims")
 TArray{T,N}(dim::NTuple{N,Int}) where {T,N} = TArray(T, dim)
 
 function TArray(T::Type, dim)

--- a/src/tarray.jl
+++ b/src/tarray.jl
@@ -100,6 +100,7 @@ end
 
 function Base.display(S::TArray)
     arr = S.orig_task.storage[S.ref][2]
+    @warn "display(::TArray) prints the originating task's storage, not the current task's storage. Please use show(::TArray) to display the current task's version of a TArray."
     display(arr)
 end
 

--- a/src/tref.jl
+++ b/src/tref.jl
@@ -40,12 +40,12 @@ function TRef(x)
     return res
 end
 
-function Base.getindex(S::TRef, I::Vararg{Int,N}) where {N}
+function Base.getindex(S::TRef, I::Vararg{Any,N}) where {N}
     _, d = task_local_storage(S.ref)
     return d[][I...]
 end
 
-function Base.setindex!(S::TRef, x, I::Vararg{Int,N}) where {N}
+function Base.setindex!(S::TRef, x, I::Vararg{Any,N}) where {N}
     n, d = task_local_storage(S.ref)
     cn   = n_copies()
     newd = d
@@ -58,13 +58,13 @@ function Base.setindex!(S::TRef, x, I::Vararg{Int,N}) where {N}
     if isa(newd[], Real)
         newd[] = x
     else
-        newd[][I...] = x
+        setindex!(newd[], x, I...)
     end
+    return newd[]
 end
 
 function Base.display(S::TRef)
-    arr = S.orig_task.storage[S.ref][2][]
-    display(arr)
+    display("Please use show(::TRef) instead.")
 end
 
 Base.show(io::IO, S::TRef) = Base.show(io::IO, task_local_storage(S.ref)[2][])

--- a/src/tref.jl
+++ b/src/tref.jl
@@ -1,0 +1,80 @@
+##########
+# TRef #
+##########
+
+"""
+    TRef(x)
+
+Implementation of an abstract data structure that
+automatically perform copy-on-write after task copying.
+
+Atomic (single-valued) TRef objects must be set or updated
+by indexing.
+
+Usage:
+
+```julia
+TRef(x)
+```
+
+Example:
+
+```julia
+z = TRef(19.2)           # Initialize an atomic value
+z[] += 31                # Increment
+
+x = TRef([1 2 3; 4 5 6]) # Initialize a multi-index object
+x[1, 3] = 999            # Set a specific index
+```
+"""
+struct TRef
+    ref :: Symbol  # object_id
+    orig_task :: Task
+    TRef() = new(gensym(), current_task())
+end
+
+function TRef(x)
+    res = TRef();
+    n = n_copies()
+    task_local_storage(res.ref, (n,Ref(x)))
+    return res
+end
+
+function Base.getindex(S::TRef, I::Vararg{Int,N}) where {N}
+    _, d = task_local_storage(S.ref)
+    return d[][I...]
+end
+
+function Base.setindex!(S::TRef, x, I::Vararg{Int,N}) where {N}
+    n, d = task_local_storage(S.ref)
+    cn   = n_copies()
+    newd = d
+    if cn > n
+        # println("[setindex!]: $(S.ref) copying data")
+        newd = deepcopy(d)
+        task_local_storage(S.ref, (cn, newd))
+    end
+
+    if isa(newd[], Real)
+        newd[] = x
+    else
+        newd[][I...] = x
+    end
+end
+
+function Base.display(S::TRef)
+    arr = S.orig_task.storage[S.ref][2][]
+    display(arr)
+end
+
+Base.show(io::IO, S::TRef) = Base.show(io::IO, task_local_storage(S.ref)[2][])
+Base.size(S::TRef) = Base.size(task_local_storage(S.ref)[2][])
+Base.ndims(S::TRef) = Base.ndims(task_local_storage(S.ref)[2][])
+
+Base.get(S::TRef) = (current_task().storage[S.ref][2][])
+
+# Implements eltype, firstindex, lastindex, and iterate
+# functions.
+for F in (:eltype, :firstindex, :lastindex, :iterate)
+    @eval Base.$F(a::TRef, args...) = $F(get(a), args...)
+end

--- a/test/tref.jl
+++ b/test/tref.jl
@@ -1,0 +1,36 @@
+using Libtask
+using Test
+
+function f_cta()
+  t = TRef(1);
+  t[] = 0;
+  while true
+    produce(t[])
+    t[]
+    t[] += 1
+  end
+end
+
+t = Task(f_cta)
+
+consume(t); consume(t)
+a = copy(t);
+consume(a); consume(a)
+
+Base.@assert consume(t) == 2
+Base.@assert consume(a) == 4
+
+x = TRef([1 2 3; 4 5 6])
+x[1, 3] = 900
+# display(x)
+
+y = TRef([1,2,3])
+y[2] = 19
+# display(y)
+
+z = TRef(19.2)
+z[] += 31
+# display(z)
+
+m = get(x)
+display(m)


### PR DESCRIPTION
This contains the initial code for the `TRef` object, which currently stores arbitrary indexable objects. I had a whole bunch of weird stuff in here earlier and decided it would be better to just adapt the `TArray` code. 

Here are a couple things I'd like comments on:
- Currently `TRef` stores things in a `Ref` object, because I was having trouble getting it to consistently store updates to references. Does anyone have a feel about whether this is a good choice?
- Are there any features we can include that work across any/all data types that are missing?
- What's the use case for this kind of thing? I wasn't sure how people might use this, so it's kind of poorly optimized at the moment.

Anyways, take a look when you've got a chance and let me know what's working and what's not.