### PR TITLE
Added warning to display(::TArray).

### DIFF
--- a/src/tarray.jl
+++ b/src/tarray.jl
@@ -100,6 +100,7 @@ end
 
 function Base.display(S::TArray)
     arr = S.orig_task.storage[S.ref][2]
+    @warn "display(::TArray) prints the originating task's storage, not the current task's storage. Please use show(::TArray) to display the current task's version of a TArray."
     display(arr)
 end
 


### PR DESCRIPTION
Regarding discussion in #3. I've only added a warning, because I think this functionality is good for REPL users to have. `show` and `println` work as intended by printing only the current task's storage.