### PR TITLE
Drop parent field from tasks.

### DIFF
--- a/deps/task.c
+++ b/deps/task.c
@@ -17,6 +17,10 @@ jl_task_t *jl_clone_task(jl_task_t *t)
     newt->stkbuf = NULL;
     newt->gcstack = NULL;
     JL_GC_PUSH1(&newt);
+ 
+    // Enable stack copying implementation for cloned tasks, see
+    //   https://github.com/JuliaLang/julia/pull/29578
+    newt->copy_stack = 1;
 
     newt->current_module = t->current_module;
     newt->state = t->state;

--- a/deps/task.c
+++ b/deps/task.c
@@ -18,7 +18,6 @@ jl_task_t *jl_clone_task(jl_task_t *t)
     newt->gcstack = NULL;
     JL_GC_PUSH1(&newt);
 
-    newt->parent = ptls->current_task;
     newt->current_module = t->current_module;
     newt->state = t->state;
     newt->start = t->start;

--- a/src/taskcopy.jl
+++ b/src/taskcopy.jl
@@ -25,7 +25,6 @@ function Base.copy(t::Task)
   newt.code = t.code
   newt.state = t.state
   newt.result = t.result
-  newt.parent = t.parent
   if :last in fieldnames(typeof(t))
     newt.last = nothing
   end


### PR DESCRIPTION
This PR prepares Libtask for Julia 1.1.0, which removes a field parent from task types (see JuliaLang/julia#29483). To solve the issue, a new binary release for `Libtask` is also needed (see https://github.com/hessammehr/LibtaskBuilder2/pull/4).