### PR TITLE
Auto tag when Project.toml updated

### DIFF
--- a/.github/workflows/BuildDylib.yaml
+++ b/.github/workflows/BuildDylib.yaml
@@ -25,6 +25,10 @@ jobs:
         uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - name: Tag commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: deps/gh-auto-tag
       - name: Install dependencies
         run: julia -e 'using Pkg; Pkg.add("BinaryProvider"); Pkg.add("BinaryBuilder");'
       - name: Build

--- a/README.md
+++ b/README.md
@@ -80,7 +80,5 @@ Disclaimer: This feature is still experimental and should only be used with caut
 ## For Developer
 
 ### Release a new version
-    1. Update the new version number in `Project.toml`;
-    2. Commit all the changes;
-    3. Tag the current commit with git, the tag name should be version number with a preceding "v";
-    4. Push the tag to the repo on GitHub, then make a release on the tag.
+    Update the new version number in `Project.toml`, a tag to that
+    version will be made by the GitHub Actions after it is pushed.

--- a/deps/gh-auto-tag
+++ b/deps/gh-auto-tag
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+git fetch --tags
+
+TAGS=($(git tag))
+CTAG=$(perl -ne 'print "v$1" if m#version\s*=\s*"(.*)"#' Project.toml)
+COMMIT=$(git rev-parse HEAD)
+
+if [[ ! " ${TAGS[@]} " =~ " ${CTAG} " ]]; then
+    GIT_REFS_URL=$(jq .repository.git_refs_url $GITHUB_EVENT_PATH | tr -d '"' | sed 's/{\/sha}//g')
+
+    curl -s -X POST $GIT_REFS_URL \
+         -H "Authorization: token ${GITHUB_TOKEN}" \
+         -d @- << EOF
+{
+  "ref": "refs/tags/$CTAG",
+  "sha": "$COMMIT"
+}
+EOF
+
+fi


### PR DESCRIPTION
#53

When version number in `Project.toml` is updated, a tag will be made according to the new version.

But we can't upload artifacts to a tag, we can only upload artifacts to a release. So now the process is:

1. someone updates the version number in `Project.toml` then commit the change
2. the push event triggers GH action, a new tag will be made on that commit
3. TagBot creates a new release on the new tag
4. GH action is triggered by the release event, then builds and uploads the artifacts