### PR TITLE
Provide error message instead of building Libtask

### DIFF
--- a/.github/workflows/Testing.yaml
+++ b/.github/workflows/Testing.yaml
@@ -19,7 +19,6 @@ jobs:
           - '1.2'
           - '1.3'
           - '1.4'
-          - 'nightly'
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/Testing.yaml
+++ b/.github/workflows/Testing.yaml
@@ -7,23 +7,35 @@ on:
     # tags: '*'
     release:
   pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.0.5', '1.1.1', '1.2.0', '1.3.0', '1.4.0']
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        version:
+          - '1.0'
+          - '1.1'
+          - '1.2'
+          - '1.3'
+          - '1.4'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
+        arch:
+          - x64
+          - x86
         exclude:
           - os: macOS-latest
-            julia-arch: x86
+            arch: x86
 
     steps:
-      - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-runtest@master
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
 license = "MIT"
 desc = "C shim for task copying in Turing"
 repo = "https://github.com/TuringLang/Libtask.jl.git"
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,6 @@
 function find_prev_tag(tag)
     project_root = (@__DIR__) |> dirname |> abspath
+    run(`git -C $project_root fetch --tags`)
     tags = readlines(`git -C $project_root tag`)
     sort!(tags)
     idx = indexin([tag], tags)[1]

--- a/src/Libtask.jl
+++ b/src/Libtask.jl
@@ -2,12 +2,14 @@ module Libtask
 
 export CTask, consume, produce, TArray, get, tzeros, tfill, TRef
 
-if !isfile(joinpath((@__DIR__) |> dirname, "deps/desp.jl"))
-    import Pkg
-    Pkg.build("Libtask")
+# Try to load the binary dependency
+if isfile(joinpath(@__DIR__, ".." , "deps", "deps.jl"))
+    include("../deps/deps.jl")
+    check_deps()
+else
+    error("Libtask is not properly installed. Please run `import Pkg; Pkg.build(\"Libtask\")`")
 end
 
-include("../deps/deps.jl"); check_deps();
 include("taskcopy.jl")
 include("tarray.jl")
 


### PR DESCRIPTION
This PR addresses https://github.com/TuringLang/Libtask.jl/issues/55.

I'm not sure if that's the best way to solve it but it avoids calling `Pkg.build("Libtask")` which apparently fails in CI tests. Moreover, it fixes the typo due to which, as far as I can see, the package was rebuilt each time it was loaded.