### PR TITLE
Correct version number

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
 license = "MIT"
 desc = "C shim for task copying in Turing"
 repo = "https://github.com/TuringLang/Libtask.jl.git"
-version = "0.4.3"
+version = "0.4.2"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"


### PR DESCRIPTION
This PR fixes the version number. Strangely, it seems Libtask 0.4.2 was not released.