### PR TITLE
Backport some features from #100

### DIFF
--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -94,11 +94,14 @@ end
 function unbox_condition(ir)
     for blk in IRTools.blocks(ir)
         vars = keys(blk)
-        for br in IRTools.branches(blk)
+        brs = IRTools.branches(blk)
+        for (i, br) in enumerate(brs)
             IRTools.isconditional(br) || continue
             cond = br.condition
-            prev_cond = IRTools.insert!(ir, cond, ir[cond])
-            ir[cond] =  IRTools.xcall(@__MODULE__, :val, prev_cond)
+            new_cond = IRTools.push!(
+                blk,
+                IRTools.xcall(@__MODULE__, :val, cond))
+            brs[i] = IRTools.Branch(br; condition=new_cond)
         end
     end
 end

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -42,7 +42,7 @@ end
 function Base.show(io::IO, instruction::Instruction)
     fun = instruction.fun
     tape = instruction.tape
-    println(io, "Instruction($(fun)), tape=$(objectid(tape)))")
+    println(io, "Instruction($(fun)$(map(val, instruction.input)), tape=$(objectid(tape)))")
 end
 
 function Base.show(io::IO, tp::Tape)
@@ -75,7 +75,8 @@ function run_and_record!(tape::Tape, f, args...)
     f = val(f) # f maybe a Boxed closure
     output = try
         box(f(map(val, args)...))
-    catch
+    catch e
+        @warn e
         any_box(nothing)
     end
     ins = Instruction(f, args, output, tape)

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -108,7 +108,6 @@ end
 end
 
 function produce(val)
-    # put!(ttask.produce_ch, val)
     # take!(ttask.consume_ch) # wait for next consumer
     is_in_tapedtask() || return nothing
     ttask = current_task().storage[:tapedtask]

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -108,7 +108,6 @@ end
 end
 
 function produce(val)
-    # take!(ttask.consume_ch) # wait for next consumer
     is_in_tapedtask() || return nothing
     ttask = current_task().storage[:tapedtask]
     length(ttask.produced_val) > 1 &&

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -108,7 +108,6 @@ end
 end
 
 function produce(val)
-    ## error("Libtask.produce can only be directly called in a task!")
     # put!(ttask.produce_ch, val)
     # take!(ttask.consume_ch) # wait for next consumer
     is_in_tapedtask() || return nothing

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -47,7 +47,9 @@ function TapedTask(tf::TapedFunction, args...)
     return t
 end
 
-TapedTask(f, args...) = TapedTask(TapedFunction(f, arity=length(args)), args...) # Issue: evaluating model without a trace
+# Issue: evaluating model without a trace, see 
+# https://github.com/TuringLang/Turing.jl/pull/1757#diff-8d16dd13c316055e55f300cd24294bb2f73f46cbcb5a481f8936ff56939da7ceR329
+TapedTask(f, args...) = TapedTask(TapedFunction(f, arity=length(args)), args...) 
 TapedTask(t::TapedTask, args...) = TapedTask(func(t), args...)
 func(t::TapedTask) = t.tf.func
 


### PR DESCRIPTION
This PR backports the robust `produce` mechanism from #100 (leaving out `InstructionTape`). During debugging https://github.com/TuringLang/Turing.jl/pull/1757, I found some issues with the `InstructionTape`. Addressing these issues might take more time and is not necessary for now. With this PR and the new model evaluation API (https://github.com/TuringLang/Turing.jl/pull/1757), we can switch Turing to use the new `Libtask`  without `InstructionTape`. 

