### PR TITLE
Add refs to integration tests

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: TuringLang, repo: AdvancedPS.jl, ref: taped-libtask}
+          - {user: TuringLang, repo: AdvancedPS.jl}
           - {user: TuringLang, repo: Turing.jl, ref: hg/new-libtask2}
 
     steps:

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: TuringLang, repo: AdvancedPS.jl}
-          - {user: TuringLang, repo: Turing.jl}
+          - {user: TuringLang, repo: AdvancedPS.jl, ref: taped-libtask}
+          - {user: TuringLang, repo: Turing.jl, ref: hg/new-libtask2}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This way, the tests are actually executed instead of skipped in the `try catch` block due to incompatible versions. But, I also understand now that it's hard to do integration tests when changes need to be made at two repositories. Anyway, adding the integration tests here is nice because it's now easier to see what needs to be done and for the reviewer to see what the current status is.