### PR TITLE
Deepcopy `args` in `CTask` constructor to avoid sharing arguments

### DIFF
--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -61,7 +61,7 @@ end
 
 # Issue: evaluating model without a trace, see
 # https://github.com/TuringLang/Turing.jl/pull/1757#diff-8d16dd13c316055e55f300cd24294bb2f73f46cbcb5a481f8936ff56939da7ceR329
-TapedTask(f, args...) = TapedTask(TapedFunction(f, arity=length(args)), args...)
+TapedTask(f, args...) = TapedTask(TapedFunction(f, arity=length(args)), (deepcopy.(args))...)
 TapedTask(t::TapedTask, args...) = TapedTask(func(t), args...)
 func(t::TapedTask) = t.tf.func
 

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -61,7 +61,7 @@ end
 
 # Issue: evaluating model without a trace, see
 # https://github.com/TuringLang/Turing.jl/pull/1757#diff-8d16dd13c316055e55f300cd24294bb2f73f46cbcb5a481f8936ff56939da7ceR329
-TapedTask(f, args...) = TapedTask(TapedFunction(f, arity=length(args)), (deepcopy.(args))...)
+TapedTask(f, args...) = TapedTask(TapedFunction(f, arity=length(args)), deepcopy.(args)...)
 TapedTask(t::TapedTask, args...) = TapedTask(func(t), args...)
 func(t::TapedTask) = t.tf.func
 


### PR DESCRIPTION
Sharing arguments (e.g. `varinfo`) in `CTask` might be causing some issues if we evaluate the model in parallel on multiple threads (see e.g., [here](https://github.com/TuringLang/Turing.jl/runs/4865925201?check_suite_focus=true#step:6:4409)). This works fine previously because the model evaluator was not shared until https://github.com/TuringLang/Turing.jl/pull/1757. That is, every time model is (re-)evaluated,  `varinfo` is deep-copied implicitly in the `evaluate!!` pipeline (possibly via `DynamicPPL.resetlogp!!(varinfo)`??).  


Update: the[ `reset_model`](https://github.com/TuringLang/AdvancedPS.jl/blob/hg/update-libtask-api/src/container.jl#L32) function seems also handles this while copying particles.