### PR TITLE
Fix non-concrete type near TRCache

### DIFF
--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -36,10 +36,8 @@ mutable struct ReturnInstruction{TA, T<:Taped} <: AbstractInstruction
     tape::T
 end
 
-const TRCache = LRU{Any, Any}(maxsize=10)
-
 mutable struct TapedFunction{F} <: Taped
-    func::F # maybe a function, a constructor, or a callable obejct
+    func::F # maybe a function, a constructor, or a callable object
     arity::Int
     ir::IRTools.IR
     tape::RawTape
@@ -53,7 +51,7 @@ mutable struct TapedFunction{F} <: Taped
         cache_key = (f, typeof.(args)...)
 
         if cache && haskey(TRCache, cache_key) # use cache
-            cached_tf = TRCache[cache_key]
+            cached_tf = TRCache[cache_key]::TapedFunction{F}
             tf = copy(cached_tf)
             tf.counter = 1
             return tf
@@ -76,6 +74,8 @@ mutable struct TapedFunction{F} <: Taped
         return tf
     end
 end
+
+const TRCache = LRU{Tuple, TapedFunction}(maxsize=10)
 
 ## methods for Box
 val(x) = x

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -1,6 +1,6 @@
 struct TapedTaskException
     exc::Exception
-    backtrace
+    backtrace::Vector{Any}
 end
 
 struct TapedTask


### PR DESCRIPTION
Very minor change. This fixes non-concrete types reported by
```julia
TapedTask(f, args...)
```
and
```julia
TapedFunction(f, args...; cache=true, init=true)
```
The compiler wasn't able to determine the type of `TRCache[cache_key]` which makes sense.

Also, I've tried to narrow down the types of `TRCache` which makes things slightly easier for the readers and the compiler.

Same for `TapedTaskException.backtrace`.