### PR TITLE
Replace `eval` by generated function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
 license = "MIT"
 desc = "Tape based task copying in Turing"
 repo = "https://github.com/TuringLang/Libtask.jl.git"
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 IRTools = "7869d1d1-7146-5819-86e3-90919afe41df"

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -173,12 +173,25 @@ function (instr::Instruction{F})() where F
     end
 end
 
+"""
+    __new__(T, args)
+
+Return a new instance of `T` with `args` even when there is no inner constructor for these args.
+Source: https://discourse.julialang.org/t/create-a-struct-with-uninitialized-fields/6967/5
+"""
+@generated function __new__(T, args)::T
+    return Expr(:splatnew, :T, :args)
+end
+
 function _new end
 function (instr::Instruction{typeof(_new)})()
     # catch run-time exceptions / errors.
     try
-        expr = Expr(:new, map(val, instr.input)...)
-        output = eval(expr)
+        input = map(val, instr.input)
+        T = input[1]
+        args = input[2:end]
+        output = __new__(T, args)
+
         instr.output.val = output
         instr.tape.counter += 1
     catch e

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -179,7 +179,7 @@ end
 Return a new instance of `T` with `args` even when there is no inner constructor for these args.
 Source: https://discourse.julialang.org/t/create-a-struct-with-uninitialized-fields/6967/5
 """
-@generated function __new__(T, args)::T
+@generated function __new__(T, args)
     return Expr(:splatnew, :T, :args)
 end
 


### PR DESCRIPTION
Benchmarked on Turing.jl/test/stdlib/RandomMeasures.jl

```
julia> @benchmark run_chain() # eval (before PR)
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 15.231 s (1.52% GC) to evaluate,
 with a memory estimate of 679.26 MiB, over 9452913 allocations.

julia> @benchmark run_chain() # splatnew (after PR)
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 14.665 s (1.55% GC) to evaluate,
 with a memory estimate of 655.23 MiB, over 8972863 allocations.

julia> @benchmark run_chain() # eval (before PR)
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 16.465 s (1.41% GC) to evaluate,
 with a memory estimate of 679.21 MiB, over 9452903 allocations.

julia> @benchmark run_chain() # splatnew (after PR)
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 15.409 s (1.50% GC) to evaluate,
 with a memory estimate of 655.34 MiB, over 8972879 allocations.
```

So about 3.5% runtime reduction and 5% allocations reduction on that test.

Would be good to run some more tests, but so far it looks promising.

ProfileSVG outputs look as follows.

**before PR**

![image](https://user-images.githubusercontent.com/20724914/154372964-3ea72be7-8300-4336-be3d-48d925f3f50b.png)

**After PR**

![image](https://user-images.githubusercontent.com/20724914/154373011-868bfdcc-e55d-4d05-9275-77f85638ac5d.png)

