### PR TITLE
Bugfix in running TapedFunction.

### DIFF
--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -116,10 +116,11 @@ end
 @inline val(x::TapedFunction) = x.func
 @inline result(t::TapedFunction) = t.bindings[t.retval]
 
-function (tf::TapedFunction)(args...; callback=nothing)
-    # reset counter and retval
-    tf.counter = 1;
-    tf.retval = :none;
+function (tf::TapedFunction)(args...; callback=nothing, startover=true)
+    if startover # reset counter and retval to run from the start
+        tf.counter = 1;
+        tf.retval = :none;
+    end
 
     # set args
     if tf.counter <= 1

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -116,8 +116,8 @@ end
 @inline val(x::TapedFunction) = x.func
 @inline result(t::TapedFunction) = t.bindings[t.retval]
 
-function (tf::TapedFunction)(args...; callback=nothing, continue=false)
-    if !continue # reset counter and retval to run from the start
+function (tf::TapedFunction)(args...; callback=nothing, continuation=false)
+    if !continuation # reset counter and retval to run from the start
         tf.counter = 1;
         tf.retval = :none;
     end

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -116,8 +116,8 @@ end
 @inline val(x::TapedFunction) = x.func
 @inline result(t::TapedFunction) = t.bindings[t.retval]
 
-function (tf::TapedFunction)(args...; callback=nothing, startover=true)
-    if startover # reset counter and retval to run from the start
+function (tf::TapedFunction)(args...; callback=nothing, continue=false)
+    if !continue # reset counter and retval to run from the start
         tf.counter = 1;
         tf.retval = :none;
     end

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -117,6 +117,10 @@ end
 @inline result(t::TapedFunction) = t.bindings[t.retval]
 
 function (tf::TapedFunction)(args...; callback=nothing)
+    # reset counter and retval
+    tf.counter = 1;
+    tf.retval = :none;
+
     # set args
     if tf.counter <= 1
         haskey(tf.bindings, :_1) && _update_var!(tf, :_1, tf.func)

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -32,7 +32,7 @@ end
 
 function wrap_task(tf, produce_ch, consume_ch, args...)
     try
-        tf(args...; callback=producer, continue=true)
+        tf(args...; callback=producer, continuation=true)
     catch e
         bt = catch_backtrace()
         put!(produce_ch, TapedTaskException(e, bt))

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -32,7 +32,7 @@ end
 
 function wrap_task(tf, produce_ch, consume_ch, args...)
     try
-        tf(args...; callback=producer, startover=false)
+        tf(args...; callback=producer, continue=true)
     catch e
         bt = catch_backtrace()
         put!(produce_ch, TapedTaskException(e, bt))

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -32,7 +32,7 @@ end
 
 function wrap_task(tf, produce_ch, consume_ch, args...)
     try
-        tf(args...; callback=producer)
+        tf(args...; callback=producer, startover=false)
     catch e
         bt = catch_backtrace()
         put!(produce_ch, TapedTaskException(e, bt))


### PR DESCRIPTION
I noticed a subtle bug while investigating the performance benchmarks in #133. It turns out that we never run the taped function in `@btime` (more precisely, `tf` is only run once) because the `tf.counter` variable is not reset after each run. 


Benchmark results for this PR: 

```julia

benchmarking rosenbrock...
  Run Original Function:  390.527 μs (16 allocations: 6.10 MiB)
  Run TapedFunction:  479.145 μs (282 allocations: 6.11 MiB)
  Run TapedFunction (compiled):  497.135 μs (309 allocations: 6.11 MiB)
benchmarking ackley...
  Run Original Function:  1.396 ms (0 allocations: 0 bytes)
  Run TapedFunction:  770.484 ms (16698219 allocations: 445.53 MiB)
  Run TapedFunction (compiled):  743.913 ms (18498246 allocations: 592.02 MiB)
benchmarking matrix_test...
  Run Original Function:  95.125 μs (16 allocations: 469.22 KiB)
  Run TapedFunction:  121.585 μs (322 allocations: 477.91 KiB)
  Run TapedFunction (compiled):  122.064 μs (352 allocations: 480.67 KiB)
benchmarking neural_net...
  Run Original Function:  552.198 ns (4 allocations: 576 bytes)
  Run TapedFunction:  4.707 μs (75 allocations: 3.06 KiB)
  Run TapedFunction (compiled):  4.596 μs (83 allocations: 3.73 KiB)
```

Before this PR (copied from https://github.com/TuringLang/Libtask.jl/pull/133#issuecomment-1076110203) 

```julia
benchmarking rosenbrock...
  Run Original Function:  998.907 μs (16 allocations: 6.10 MiB)
  Run TapedFunction:  23.594 ns (0 allocations: 0 bytes)
  Run TapedFunction (compiled):  38.710 ns (1 allocation: 48 bytes)
benchmarking ackley...
  Run Original Function:  2.027 ms (0 allocations: 0 bytes)
  Run TapedFunction:  23.494 ns (0 allocations: 0 bytes)
  Run TapedFunction (compiled):  40.625 ns (1 allocation: 48 bytes)
benchmarking matrix_test...
  Run Original Function:  154.501 μs (16 allocations: [469]
  Run TapedFunction:  22.066 ns (0 allocations: 0 bytes)
  Run TapedFunction (compiled):  38.005 ns (1 allocation: 48 bytes)
benchmarking neural_net...
  Run Original Function:  708.276 ns (4 allocations: 576 bytes)
  Run TapedFunction:  28.743 ns (0 allocations: 0 bytes)
  Run TapedFunction (compiled):  48.381 ns (1 allocation: 48 bytes)
```