### PR TITLE
Update args at copy

### DIFF
--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -373,9 +373,16 @@ function copy_bindings(old::Dict{Symbol, Any})
     return newb
 end
 
-function Base.copy(tf::TapedFunction)
+function Base.copy(tf::TapedFunction, args...)
     # create a new uninitialized TapedFunction
     new_tf = TapedFunction(tf)
     new_tf.bindings = copy_bindings(tf.bindings)
+    if !isempty(args)
+        length(args) > tf.arity && throw("Number of updates for `args` is greater than generated function arity $(tf.arity)")
+        for (i, arg) in enumerate(args)
+            slot = Symbol("_", i + 1)
+            haskey(tf.bindings, slot) && _update_var!(tf, slot, arg)
+       end
+    end
     return new_tf
 end

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -373,16 +373,9 @@ function copy_bindings(old::Dict{Symbol, Any})
     return newb
 end
 
-function Base.copy(tf::TapedFunction, args...)
+function Base.copy(tf::TapedFunction)
     # create a new uninitialized TapedFunction
     new_tf = TapedFunction(tf)
     new_tf.bindings = copy_bindings(tf.bindings)
-    if !isempty(args)
-        length(args) > tf.arity && throw("Number of updates for `args` is greater than generated function arity $(tf.arity)")
-        for (i, arg) in enumerate(args)
-            slot = Symbol("_", i + 1)
-            haskey(tf.bindings, slot) && _update_var!(tf, slot, arg)
-       end
-    end
     return new_tf
 end

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -169,7 +169,7 @@ function Base.copy(t::TapedTask; args=())
     else
         tape_copy.(t.args)
     end
-    new_t = TapedTask(tf, real_args...)
+    new_t = TapedTask(tf, task_args...)
     storage = t.task.storage::IdDict{Any,Any}
     new_t.task.storage = copy(storage)
     new_t.task.storage[:tapedtask] = new_t

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -3,9 +3,10 @@ struct TapedTaskException
     backtrace::Vector{Any}
 end
 
-struct TapedTask{F}
+struct TapedTask{F, AT<:Tuple}
     task::Task
     tf::TapedFunction{F}
+    args::AT
     produce_ch::Channel{Any}
     consume_ch::Channel{Int}
     produced_val::Vector{Any}
@@ -13,10 +14,11 @@ struct TapedTask{F}
     function TapedTask(
         t::Task,
         tf::TapedFunction{F},
+        args::AT,
         produce_ch::Channel{Any},
         consume_ch::Channel{Int}
-    ) where {F}
-        new{F}(t, tf, produce_ch, consume_ch, Any[])
+    ) where {F, AT<:Tuple}
+        new{F, AT}(t, tf, args, produce_ch, consume_ch, Any[])
     end
 end
 
@@ -55,7 +57,7 @@ function TapedTask(tf::TapedFunction, args...)
     produce_ch = Channel()
     consume_ch = Channel{Int}()
     task = @task wrap_task(tf, produce_ch, consume_ch, args...)
-    t = TapedTask(task, tf, produce_ch, consume_ch)
+    t = TapedTask(task, tf, args, produce_ch, consume_ch)
     task.storage === nothing && (task.storage = IdDict())
     task.storage[:tapedtask] = t
     return t
@@ -159,9 +161,10 @@ Base.IteratorEltype(::Type{<:TapedTask}) = Base.EltypeUnknown()
 
 # copy the task
 
-function Base.copy(t::TapedTask)
+function Base.copy(t::TapedTask; args=())
     tf = copy(t.tf)
-    new_t = TapedTask(tf)
+    real_args = typeof(args) == typeof(t.args) ? args : tape_copy.(t.args)
+    new_t = TapedTask(tf, real_args...)
     storage = t.task.storage::IdDict{Any,Any}
     new_t.task.storage = copy(storage)
     new_t.task.storage[:tapedtask] = new_t

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -159,9 +159,9 @@ Base.IteratorEltype(::Type{<:TapedTask}) = Base.EltypeUnknown()
 
 # copy the task
 
-function Base.copy(t::TapedTask, args...)
-    tf = copy(t.tf, args...)
-    new_t = TapedTask(tf, args...)
+function Base.copy(t::TapedTask)
+    tf = copy(t.tf)
+    new_t = TapedTask(tf)
     storage = t.task.storage::IdDict{Any,Any}
     new_t.task.storage = copy(storage)
     new_t.task.storage[:tapedtask] = new_t

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -163,7 +163,12 @@ Base.IteratorEltype(::Type{<:TapedTask}) = Base.EltypeUnknown()
 
 function Base.copy(t::TapedTask; args=())
     tf = copy(t.tf)
-    real_args = typeof(args) == typeof(t.args) ? args : tape_copy.(t.args)
+    real_args = if length(args) > 0
+        typeof(args) == typeof(t.args) || error("bad arguments")
+        args
+    else
+        tape_copy.(t.args)
+    end
     new_t = TapedTask(tf, real_args...)
     storage = t.task.storage::IdDict{Any,Any}
     new_t.task.storage = copy(storage)

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -163,7 +163,7 @@ Base.IteratorEltype(::Type{<:TapedTask}) = Base.EltypeUnknown()
 
 function Base.copy(t::TapedTask; args=())
     tf = copy(t.tf)
-    real_args = if length(args) > 0
+    task_args = if length(args) > 0
         typeof(args) == typeof(t.args) || error("bad arguments")
         args
     else

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -159,9 +159,9 @@ Base.IteratorEltype(::Type{<:TapedTask}) = Base.EltypeUnknown()
 
 # copy the task
 
-function Base.copy(t::TapedTask)
-    tf = copy(t.tf)
-    new_t = TapedTask(tf)
+function Base.copy(t::TapedTask, args...)
+    tf = copy(t.tf, args...)
+    new_t = TapedTask(tf, args...)
     storage = t.task.storage::IdDict{Any,Any}
     new_t.task.storage = copy(storage)
     new_t.task.storage[:tapedtask] = new_t

--- a/test/tapedtask.jl
+++ b/test/tapedtask.jl
@@ -184,4 +184,20 @@
             end
         end
     end
+
+    @testset "Issues" begin
+        @testset "Issue-140, copy unstarted task" begin
+            function f(x)
+                for i in 1:3
+                    produce(i + x)
+                end
+            end
+
+            ttask = TapedTask(f, 3)
+            ttask2 = copy(ttask)
+            @test consume(ttask2) == 4
+            ttask3 = copy(ttask; args=(4,))
+            @test consume(ttask3) == 5
+        end
+    end
 end


### PR DESCRIPTION
In `AdvancedPS` we often need to mutate the input of the the `TapedFunction` to handle random streams. It would be great if we could do something like:
```julia
function (model::Model) (rng::Random.AbstractRNG)
   ...
end

rng1 = Random.MersenneTwister()
task = Litbtask.TapedTask(model, rng1)

Libtask.consume(task)

new_rng = Random.MersenneTwister()
task2 = Libtask.copy(task, new_rng)

Libtask.consume(task) # Generates random numbers from rng1
Libtask.consume(task2) # Generates random numbers from new_rng
```

but for this to work we need to update the `args...` and ` bindings` appropriately when we `copy` the running task. 

This is just a draft, I'm not sure about all the implications of this change, especially with #138 