### PR TITLE
Adjust to julialang/julia#50943

### DIFF
--- a/src/Libtask.jl
+++ b/src/Libtask.jl
@@ -8,10 +8,15 @@ export TapedTask, consume, produce
 export TArray, tzeros, tfill, TRef # legacy types back compat
 
 
-const TypedSlot = @static if isdefined(Core, :TypedSlot) # Julia v1.10 removed Core.TypedSlot
-    Core.TypedSlot
+@static if isdefined(Core, :TypedSlot) || isdefined(Core.Compiler, :TypedSlot)
+    # Julia v1.10 removed Core.TypedSlot
+    const TypedSlot = @static if isdefined(Core, :TypedSlot)
+        Core.TypedSlot
+    else
+        Core.Compiler.TypedSlot
+    end
 else
-    Core.Compiler.TypedSlot
+    struct TypedSlot end # Dummy
 end
 
 include("tapedfunction.jl")


### PR DESCRIPTION
This is enough to get Libtask.jl pre-compiling again on nightly versions of Julia.