### PR TITLE
Subtape + Fix Recursion

### DIFF
--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -529,5 +529,5 @@ end
 # but if we instantiate new TapedTask, we have to reset the counters of cached tapes
 function reset_counters!(tf::TapedFunction)
     tf.counter = 1
-    reset_counters!.(values(tf.subtapes))
+    foreach(reset_counters!, values(tf.subtapes))
 end

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -420,12 +420,6 @@ function translate!!(var::IRVar, line::Expr,
         # inferred as constants: we only optimize primitive and datatype constants for now. For
         # optimised function calls, we will evaluate the function at compile-time and cache results.
 
-        # even if return value is const. The call may has side-effects.
-        # In particular, it may contain produce statements.
-        # if isconst
-        #     v = ir.ssavaluetypes[var.id].val
-        #     _canbeoptimized(v) && return _const_instruction(var, v, bindings, ir)
-        # end
         args = map(_bind_fn, line.args)
         # args[1] is the function
         func = line.args[1]

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -523,3 +523,10 @@ function Base.copy(tf::TapedFunction)
     new_tf.subtapes = IdDict{Any,TapedFunction}(func => copy(subtape) for (func, subtape) in tf.subtapes)
     return new_tf
 end
+
+# when copying we want to keep the counters
+# but if we instantiate new TapedTask, we have to reset the counters of cached tapes
+function reset_counters!(tf::TapedFunction)
+    tf.counter = 1
+    reset_counters!.(values(tf.subtapes))
+end

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -222,7 +222,6 @@ function (instr::Instruction{F})(tf::TapedFunction, callback=nothing) where F
         else
             tf_inner = get!(tf.subtapes, instr, TapedFunction(func, inputs..., cache=true))
             tf_inner(inputs...; callback=callback, continuation=true)
-            @assert tf_inner.retval_binding_slot != 0 # tf_inner should return
         end
         _update_var!(tf, instr.output, output)
         tf.counter += 1

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -67,7 +67,8 @@ mutable struct TapedFunction{F, TapeType}
         if cache && haskey(TRCache, cache_key) # use cache
             cached_tf = TRCache[cache_key]::TapedFunction{F, T}
             tf = copy(cached_tf)
-            tf.counter = 1
+            # we have to reset the counters of cached tapes (also the counters of subtapes)
+            reset_counters!(tf)
             return tf
         end
         ir = _infer(f, args_type)

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -221,7 +221,9 @@ function (instr::Instruction{F})(tf::TapedFunction, callback=nothing) where F
         output = if is_primitive(func, inputs...)
             func(inputs...)
         else
-            tf_inner = get!(tf.subtapes, instr, TapedFunction(func, inputs..., cache=true))
+            tf_inner = get!(tf.subtapes, instr) do
+                TapedFunction(func, inputs...; cache=true)
+            end
             # continuation=false breaks "Multiple func calls subtapes" and "Copying task with subtapes"
             tf_inner(inputs...; callback=callback, continuation=true)
         end

--- a/src/tapedfunction.jl
+++ b/src/tapedfunction.jl
@@ -221,6 +221,7 @@ function (instr::Instruction{F})(tf::TapedFunction, callback=nothing) where F
             func(inputs...)
         else
             tf_inner = get!(tf.subtapes, instr, TapedFunction(func, inputs..., cache=true))
+            # continuation=false breaks "Multiple func calls subtapes" and "Copying task with subtapes"
             tf_inner(inputs...; callback=callback, continuation=true)
         end
         _update_var!(tf, instr.output, output)

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -122,7 +122,7 @@ end
 function produce(val)
     is_in_tapedtask() || return nothing
     ttask = current_task().storage[:tapedtask]::TapedTask
-    length(ttask.produced_val) > 1 &&
+    length(ttask.produced_val) > 0 &&
         error("There is a produced value which is not consumed.")
     push!(ttask.produced_val, val)
     return nothing

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -74,6 +74,7 @@ function TapedTask(f, args...; deepcopy_types=nothing) # deepcoy Array and Ref b
         deepcopy = Union{BASE_COPY_TYPES, deepcopy_types}
     end
     tf = TapedFunction(f, args...; cache=true, deepcopy_types=deepcopy)
+    reset_counters!(tf) # we have to reset the counters of cached tapes
     TapedTask(tf, args...)
 end
 

--- a/src/tapedtask.jl
+++ b/src/tapedtask.jl
@@ -74,7 +74,6 @@ function TapedTask(f, args...; deepcopy_types=nothing) # deepcoy Array and Ref b
         deepcopy = Union{BASE_COPY_TYPES, deepcopy_types}
     end
     tf = TapedFunction(f, args...; cache=true, deepcopy_types=deepcopy)
-    reset_counters!(tf) # we have to reset the counters of cached tapes
     TapedTask(tf, args...)
 end
 

--- a/test/tape_copy.jl
+++ b/test/tape_copy.jl
@@ -192,4 +192,60 @@
         @test consume(ttask) == 1
         @test consume(ttask2) == 2
     end
+
+    @testset "Copying task with subtapes" begin
+        function f()
+            produce(1)
+            produce(2)
+        end
+
+        function g()
+            f()
+        end
+
+        Libtask.is_primitive(::typeof(f), args...) = false
+
+        ttask = TapedTask(g)
+        @test consume(ttask) == 1
+
+        ttask2 = copy(ttask)
+        @test consume(ttask2) == 2
+        @test consume(ttask) == 2
+
+        @test consume(ttask2) === nothing
+        @test consume(ttask) === nothing
+    end
+
+    @testset "Multiple func calls subtapes" begin
+        function f()
+            produce(1)
+            produce(2)
+        end
+
+        function g()
+            f()
+            f()
+        end
+
+        Libtask.is_primitive(::typeof(f), args...) = false
+
+        ttask = TapedTask(g)
+
+        @test consume(ttask) == 1
+        ttask2 = copy(ttask)
+        @test consume(ttask) == 2
+        @test consume(ttask) == 1
+        ttask3 = copy(ttask)
+        @test consume(ttask) == 2
+        @test consume(ttask) === nothing
+
+        @test consume(ttask2) == 2
+        @test consume(ttask2) == 1
+        @test consume(ttask2) == 2
+        @test consume(ttask2) === nothing
+
+        @test consume(ttask3) == 2
+        @test consume(ttask3) === nothing
+
+    end
 end

--- a/test/tape_copy.jl
+++ b/test/tape_copy.jl
@@ -246,6 +246,5 @@
 
         @test consume(ttask3) == 2
         @test consume(ttask3) === nothing
-
     end
 end

--- a/test/tape_copy.jl
+++ b/test/tape_copy.jl
@@ -194,18 +194,18 @@
     end
 
     @testset "Copying task with subtapes" begin
-        function f()
+        function f2()
             produce(1)
             produce(2)
         end
 
-        function g()
-            f()
+        function g2()
+            f2()
         end
 
-        Libtask.is_primitive(::typeof(f), args...) = false
+        Libtask.is_primitive(::typeof(f2), args...) = false
 
-        ttask = TapedTask(g)
+        ttask = TapedTask(g2)
         @test consume(ttask) == 1
 
         ttask2 = copy(ttask)
@@ -217,19 +217,19 @@
     end
 
     @testset "Multiple func calls subtapes" begin
-        function f()
+        function f3()
             produce(1)
             produce(2)
         end
 
-        function g()
-            f()
-            f()
+        function g3()
+            f3()
+            f3()
         end
 
-        Libtask.is_primitive(::typeof(f), args...) = false
+        Libtask.is_primitive(::typeof(f3), args...) = false
 
-        ttask = TapedTask(g)
+        ttask = TapedTask(g3)
 
         @test consume(ttask) == 1
         ttask2 = copy(ttask)

--- a/test/tapedtask.jl
+++ b/test/tapedtask.jl
@@ -157,8 +157,6 @@
         end
 
         @testset "Too much producers" begin
-            
-
             function f()
                 produce(1)
                 produce(2)

--- a/test/tapedtask.jl
+++ b/test/tapedtask.jl
@@ -155,5 +155,21 @@
                 @test ttask2.task.exception isa BoundsError
             end
         end
+
+        @testset "Too much producers" begin
+            
+
+            function f()
+                produce(1)
+                produce(2)
+            end
+
+            function g()
+                f()
+            end
+
+            ttask = TapedTask(g)
+            @test_throws Exception consume(ttask)
+        end
     end
 end

--- a/test/tapedtask.jl
+++ b/test/tapedtask.jl
@@ -169,5 +169,22 @@
             ttask = TapedTask(g)
             @test_throws Exception consume(ttask)
         end
+
+        @testset "Multiple producers for non-primitive" begin
+            function f2()
+                produce(1)
+                produce(2)
+            end
+            Libtask.is_primitive(::typeof(f2), args...) = false
+
+            function g2()
+                f2()
+            end
+
+            ttask = TapedTask(g2)
+            @test consume(ttask) == 1
+            @test consume(ttask) == 2
+            @test consume(ttask) === nothing
+        end
     end
 end

--- a/test/tapedtask.jl
+++ b/test/tapedtask.jl
@@ -186,5 +186,28 @@
             @test consume(ttask) == 2
             @test consume(ttask) === nothing
         end
+
+        @testset "Run two times" begin
+            function f4()
+                produce(2)
+            end
+
+            function g4()
+                produce(1)
+                f4()
+            end
+
+            Libtask.is_primitive(::typeof(f4), args...) = false
+
+            ttask = TapedTask(g4)
+            @test consume(ttask) == 1
+            @test consume(ttask) == 2
+            @test consume(ttask) === nothing
+
+            ttask = TapedTask(g4)
+            @test consume(ttask) == 1
+            @test consume(ttask) == 2
+            @test consume(ttask) === nothing
+        end
     end
 end

--- a/test/tapedtask.jl
+++ b/test/tapedtask.jl
@@ -156,7 +156,7 @@
             end
         end
 
-        @testset "Too much producers" begin
+        @testset "Too many producers" begin
             function f()
                 produce(1)
                 produce(2)

--- a/test/tf.jl
+++ b/test/tf.jl
@@ -37,8 +37,6 @@ Libtask.is_primitive(::typeof(foo), args...) = false
         @test typeof(r) === Float64
     end
     @testset "recurse into function" begin
-        
-    end
         function recurse(n::Int)
             if n == 0
                 return 0

--- a/test/tf.jl
+++ b/test/tf.jl
@@ -37,11 +37,8 @@ Libtask.is_primitive(::typeof(foo), args...) = false
         @test typeof(r) === Float64
     end
     @testset "recurse into function" begin
-        # tf = Libtask.TapedFunction(bar, 5.0)
-        # count = 0
-        # tf(4.0; callback=() -> (count += 1))
-        # @test count == 9
-
+        
+    end
         function recurse(n::Int)
             if n == 0
                 return 0

--- a/test/tf.jl
+++ b/test/tf.jl
@@ -37,9 +37,75 @@ Libtask.is_primitive(::typeof(foo), args...) = false
         @test typeof(r) === Float64
     end
     @testset "recurse into function" begin
-        tf = Libtask.TapedFunction(bar, 5.0)
-        count = 0
-        tf(4.0; callback=() -> (count += 1))
-        @test count == 9
+        # tf = Libtask.TapedFunction(bar, 5.0)
+        # count = 0
+        # tf(4.0; callback=() -> (count += 1))
+        # @test count == 9
+
+        function recurse(n::Int)
+            if n == 0
+                return 0
+            end
+            recurse(n-1)
+            produce(n)
+        end
+        Libtask.is_primitive(::typeof(recurse), args...) = false
+        ttask = TapedTask(recurse, 3)
+
+        @test consume(ttask) == 1
+        @test consume(ttask) == 2
+        @test consume(ttask) == 3
+        @test consume(ttask) === nothing
+
+        function recurse2(n::Int)
+            if n == 0
+                return 0
+            end
+            produce(n)
+            recurse2(n-1)
+        end
+        Libtask.is_primitive(::typeof(recurse2), args...) = false
+        ttask = TapedTask(recurse2, 3)
+
+        @test consume(ttask) == 3
+        @test consume(ttask) == 2
+        @test consume(ttask) == 1
+        @test consume(ttask) === nothing
+    end
+
+    @testset "Not optimize mutating call" begin
+
+        function f!(a)
+            a[1] = 2
+            return 1
+        end
+        
+        function g1()
+            a = [1,2]
+            a[2] = f!(a)
+            produce(a[1])
+        end
+        
+        ttask = TapedTask(g1)
+        @test consume(ttask) == 2
+        @test consume(ttask) === nothing
+    end
+
+    @testset "Not optimize producing call" begin
+        function f2()
+            produce(2)
+            return 1
+        end
+
+        function g2()
+            a = [1]
+            a[1] = f2()
+            produce(a[1])
+        end
+
+        ttask = TapedTask(g2)
+        @test consume(ttask) == 2
+        @test consume(ttask) == 1
+        @test consume(ttask) === nothing        
     end
 end


### PR DESCRIPTION
Hello,

I am not too familiar with the code base, but I updated the subtaping functionality to work for my own project.
Maybe you find these fixes useful.

- Added `subtapes` property to `TapedFunction`
This is important for task copying to work. We also have to copy the subtapes to continue in the correct instruction in the copied task (e.g. if we want to continue in a subtape).
- Remove translation optimisation based on constant return types of calls. A call may contain a produce statement but returns a constant. In the old implementation this call would have been optimised.
- Added a few test cases for subtapes that did not pass in the old implementation, but now do.

Best,
Markus