### PR TITLE
Fix benchmarks 

### DIFF
--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -14,20 +14,15 @@ function benchmark_driver!(f, x...; f_displayname=string(f))
     @btime $f($(x)...)
     GC.gc()
 
-    print("  Run TapedFunction:")
-    @btime $tf($(x)...)
-    GC.gc()
-
-    ctf = Libtask.compile(tf)
-    print("  Run TapedFunction (compiled):")
-    @btime $ctf($(x)...)
-    GC.gc()
+    # print("  Run TapedFunction:")
+    # @btime $tf($(x)...)
+    # GC.gc()
 
     print("  Run TapedTask: ")
     x = (x[1:(end - 1)]..., produce)
     # show the number of produce calls inside `f`
     function f_task(f, x; verbose=false)
-        tt = TapedTask(f, x...)
+        tt = TapedTask(nothing, f, x...)
         c = 0
         while consume(tt) !== nothing
             c += 1

--- a/perf/benchmark.jl
+++ b/perf/benchmark.jl
@@ -8,7 +8,7 @@ function benchmark_driver!(f, x...; f_displayname=string(f))
     x = (x..., nothing)
 
     println("benchmarking $(f_displayname)...")
-    tf = Libtask.TapedFunction(f, x...)
+    tf = Libtask.TapedTask(nothing, f, x...)
 
     print("  Run Original Function:")
     @btime $f($(x)...)


### PR DESCRIPTION
Fixed some minor issues in benchmarks. It now runs but produces the error below

```julia
julia> benchmark_driver!(rosenbrock, x)

       ####################################################################
benchmarking rosenbrock...
ERROR: Unhandled stmt $(Expr(:loopinfo, Symbol("julia.simdloop"), nothing)) of type Expr
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] (::Libtask.var"#14#26"{…})(::Tuple{…})
    @ Libtask ~/.julia/packages/Libtask/Aw9k4/src/copyable_task.jl:708
  [3] iterate
    @ ./generator.jl:48 [inlined]
  [4] collect(itr::Base.Generator{Base.Iterators.Enumerate{…}, Libtask.var"#14#26"{…}})
    @ Base ./array.jl:791
  [5] map
    @ ./abstractarray.jl:3399 [inlined]
  [6] (::Libtask.var"#13#25"{…})(::Tuple{…})
    @ Libtask ~/.julia/packages/Libtask/Aw9k4/src/copyable_task.jl:552
  [7] iterate
    @ ./generator.jl:48 [inlined]
  [8] collect_to!(dest::Vector{…}, itr::Base.Generator{…}, offs::Int64, st::Tuple{…})
    @ Base ./array.jl:849
  [9] collect_to_with_first!(dest::Vector{…}, v1::Vector{…}, itr::Base.Generator{…}, st::Tuple{…})
    @ Base ./array.jl:827
 [10] collect(itr::Base.Generator{Base.Iterators.Zip{…}, Libtask.var"#13#25"{…}})
    @ Base ./array.jl:801
 [11] map(f::Function, A::Base.Iterators.Zip{Tuple{Vector{Libtask.BasicBlockCode.BBlock}, Vector{Vector{…}}, Vector{Vector{…}}}})
    @ Base ./abstractarray.jl:3399
 [12] derive_copyable_task_ir(ir::Libtask.BasicBlockCode.BBCode)
    @ Libtask ~/.julia/packages/Libtask/Aw9k4/src/copyable_task.jl:551
 [13] build_callable(sig::Type{Tuple{typeof(rosenbrock), Vector{Float64}, Nothing}})
    @ Libtask ~/.julia/packages/Libtask/Aw9k4/src/copyable_task.jl:59
 [14] TapedTask(::Nothing, ::Function, ::Vararg{Any}; kwargs::@Kwargs{})
    @ Libtask ~/.julia/packages/Libtask/Aw9k4/src/copyable_task.jl:202
 [15] TapedTask(::Nothing, ::Function, ::Vararg{Any})
    @ Libtask ~/.julia/packages/Libtask/Aw9k4/src/copyable_task.jl:199
 [16] benchmark_driver!(f::Function, x::Vector{Float64}; f_displayname::String)
    @ Main ./REPL[4]:5
 [17] benchmark_driver!(f::Function, x::Vector{Float64})
    @ Main ./REPL[4]:1
 [18] top-level scope
    @ REPL[7]:1
Some type information was truncated. Use `show(err)` to see complete types.
```