### PR TITLE
Support safe exception regions in `TapedTask`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# AGENTS.md
+
+## Purpose
+
+Libtask.jl provides resumable, **copyable** functions (coroutines) for Julia, with optional
+function-specific globals. [Turing.jl](https://github.com/TuringLang/Turing.jl) (via
+[AdvancedPS.jl](https://github.com/TuringLang/AdvancedPS.jl)) uses it for particle-based
+inference, where copying a partially-run task — not just resuming it — is the load-bearing
+feature.
+
+Mechanism: `Base.code_ircode_by_type` recovers typed IR; `derive_copyable_task_ir` splits it
+at every `produce` site, lifts variables that must survive a suspension into `Ref`s, and emits
+a re-enterable `MistyClosure`. `copy(::TapedTask)` deep-copies those `Ref`s to fork state.
+
+Priorities, in order: (1) `produce`/`consume`/`copy` correctness — a copy resumes
+independently and reproduces a fresh run exactly; (2) faithful control flow (branches, loops,
+phi nodes, exception regions), failing loudly and locally on unsupported constructs
+(`assert_can_handle_control_flow`) rather than resuming wrongly; (3) type stability and low
+allocation on the `consume` hot path; (4) minimal dependencies and a small IR-transform core.
+
+## Repository Layout
+
+- `src/Libtask.jl` — module entry, exports (`TapedTask`, `consume`, `produce`,
+  `get_taped_globals`, `set_taped_globals!`, `NotInTapedTaskError`).
+- `src/copyable_task.jl` — public API + `build_callable` (IR-derivation/compile/cache entry),
+  the `MistyClosure` cache, and `copy`.
+- `src/transformation.jl` — core IR transform: `produce`-site detection (`is_produce_stmt`,
+  `stmt_might_produce`), block splitting, `Ref` creation, reassembly.
+- `src/refelim.jl` — `eliminate_refs`: live-variable analysis dropping `Ref` loads/stores not
+  needed across `produce` boundaries.
+- `src/bbcode.jl` — `BasicBlockCode`, the basic-block IR repr **copied from Mooncake.jl** to
+  avoid a dependency; keep in sync with Mooncake when fixing IR bugs.
+- `src/utils.jl` — IR helpers (`replace_captures`, `optimise_ir!`, `misty_closure`,
+  `Core.Compiler` version shims).
+- `src/test_utils.jl` — `TestUtils`: the `Testcase` driver.
+- `test/` — `runtests.jl` runs Aqua + `copyable_task.jl`; `test/integration/turing/` is a
+  separate-environment Turing.jl suite.
+- `docs/src/` — `index.md` (user) and `internals.md` (documented-internals docstring index).
+
+## Working Conventions
+
+- **Lives on `Core.Compiler` internals**, unstable across Julia versions — the most fragile
+  part of the codebase. Guard version-specific behaviour with `@static if VERSION ...` (e.g.
+  `set_valid_world!`, the `get_mi` shim); test on every supported version. The `[compat]`
+  range (`~1.10.8, 1.11.6`) and the CI matrix (`.github/workflows/CI.yml`) move together.
+- Fix IR problems by making the transform correct, not by special-casing the public API.
+  `transformation.jl`/`refelim.jl` are the single source of truth for the resumable IR.
+- `produce` and `get_taped_globals(::Type)` are **reserved statements**, not real functions:
+  `produce` is `@noinline` with a dummy side-effect so the transform can find/rewrite it (it
+  never runs under `consume`). Don't "optimise away" what resists inlining/constant-folding.
+- Concrete `Core.Compiler` types (`IRCode`, `SSAValue`, …) in the transform layer are
+  load-bearing, not over-constraint; annotate as specifically as dispatch requires.
+- **Workflow for any bug fix or new feature**: investigate → root-cause → understand the big
+  picture → *verify the fix before committing to it*. Reproduce with an MWE, inspect derived IR
+  (`Libtask.generate_ir`), and confirm the hypothesis by temporarily editing or monkey-patching
+  (e.g. `@eval`-ing a replacement method, hacking the local checkout) until the MWE behaves —
+  only then write the real change. Don't edit the transform on a guess. Prefer targeted fixes
+  over new helpers or refactors; run `minimise` before committing.
+- Write clear, local errors for unsupported inputs (naked `produce`, unhandled control flow) —
+  a clear `ArgumentError` at construction beats a confusing failure in compiled IR.
+- Internals may change freely; exports, the `produce`/`consume`/`copy` contract, and names in
+  `docs/src/internals.md` need tests, docs, and stable errors — update docs when they change.
+- Format with JuliaFormatter, **blue** style: `julia -e 'using JuliaFormatter; format(".")'`.
+
+## Concurrency
+
+- `build_callable` is serialized under `build_callable_lock` (`ReentrantLock`) — deliberate:
+  IR derivation mutates a shared `ID` counter (`seed_id!`/`ID()`) and the `MistyClosure` cache,
+  and concurrent derivation segfaulted (#227). Keep all ID generation and cache mutation inside
+  this lock; don't add a second IR-deriving code path outside it.
+- `bbcode.jl` indexes its `ID` counter by `Threads.threadid()` — suspect (task migration makes
+  IDs unstable); the lock, not `threadid()`, is what makes it safe today.
+- `copy(::TapedTask)` is `deepcopy`: the copy must share **no** mutable state (`Ref`s,
+  position). Any change to state storage must keep this — test that mutating a copy doesn't
+  affect the source.
+
+## Testing
+
+- MWE first, then the smallest focused test, then broader groups. Prefer extending existing
+  `Testcase`s over adding new ones; prune with `minimise`.
+- Register behaviour as `TestUtils.Testcase`s where possible — the driver iterates the task,
+  `copy`s after every iteration, and checks every copy resumes to the same result sequence
+  (plus optional allocation flags), exercising the copy/resume contract for free. Reserve
+  bespoke `test/` code for what the driver can't express.
+- Cover control-flow variety (branches, loops, nested produce, exception regions) and varied
+  value types. Bug fixes land with a focused regression test; version/world-age fixes get an
+  isolated direct test. Check `consume` allocations (`@allocated` post-warmup) and stability
+  (`@code_warntype`) for perf-sensitive paths.
+- Never disable tests or weaken perf/allocation assertions to get CI green — ask first.
+- `test/integration/turing/` runs in its own environment and is part of the contract: transform
+  or semantics changes may need updates there even when core tests pass.
+
+## Documentation
+
+`docs/make.jl` drives Documenter; `index.md` is user-facing, `internals.md` indexes documented
+internals. Update docstrings (and `internals.md` when adding/removing a documented internal)
+when changing the public API, transform internals, or developer helpers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,22 +3,21 @@
 ## Purpose
 
 Libtask.jl provides resumable, **copyable** functions (coroutines) for Julia, with optional
-function-specific globals. [Turing.jl](https://github.com/TuringLang/Turing.jl) (via
-[AdvancedPS.jl](https://github.com/TuringLang/AdvancedPS.jl)) uses it for particle-based
-inference, where copying a partially-run task — not just resuming it — is the load-bearing
-feature.
+state private to each `TapedTask`. It supports particle-based inference in the Turing
+ecosystem, where resampling requires independent copies of partially run tasks.
 
-Mechanism: `Base.code_ircode_by_type` recovers typed IR; `derive_copyable_task_ir` splits it
-at every `produce` site, lifts variables that must survive a suspension into `Ref`s, and emits
-a re-enterable `MistyClosure`. `copy(::TapedTask)` deep-copies those `Ref`s to fork state.
+Mechanism: `Base.code_ircode_by_type` recovers typed IR. `derive_copyable_task_ir` splits it
+at every statement that may `produce` and stores SSA values needed after a suspension in
+`Ref`s; `eliminate_refs` removes unnecessary storage. `build_callable` compiles the result as
+a re-enterable `MistyClosure`. `copy(::TapedTask)` deep-copies the task-owned state.
 
-Priorities, in order: (1) `produce`/`consume`/`copy` correctness — a copy resumes
-independently and reproduces a fresh run exactly; (2) faithful control flow (branches, loops,
-phi nodes, exception regions), failing loudly and locally on unsupported constructs
-(`assert_can_handle_control_flow`) rather than resuming wrongly; (3) type stability and low
+Priorities, in order: (1) `produce`/`consume`/`copy` correctness — a copy preserves the
+source's suspension point, evolves independently, and produces the same remaining sequence;
+(2) faithful control flow (branches, loops, phi nodes, exception regions), failing locally
+on unsupported constructs rather than resuming incorrectly; (3) type stability and low
 allocation on the `consume` hot path; (4) minimal dependencies and a small IR-transform core.
 
-## Repository Layout
+## Repository layout
 
 - `src/Libtask.jl` — module entry, exports (`TapedTask`, `consume`, `produce`,
   `get_taped_globals`, `set_taped_globals!`, `NotInTapedTaskError`).
@@ -28,8 +27,8 @@ allocation on the `consume` hot path; (4) minimal dependencies and a small IR-tr
   `stmt_might_produce`), block splitting, `Ref` creation, reassembly.
 - `src/refelim.jl` — `eliminate_refs`: live-variable analysis dropping `Ref` loads/stores not
   needed across `produce` boundaries.
-- `src/bbcode.jl` — `BasicBlockCode`, the basic-block IR repr **copied from Mooncake.jl** to
-  avoid a dependency; keep in sync with Mooncake when fixing IR bugs.
+- `src/bbcode.jl` — `BasicBlockCode`, the stable-ID basic-block representation used by the
+  transform.
 - `src/utils.jl` — IR helpers (`replace_captures`, `optimise_ir!`, `misty_closure`,
   `Core.Compiler` version shims).
 - `src/test_utils.jl` — `TestUtils`: the `Testcase` driver.
@@ -37,55 +36,65 @@ allocation on the `consume` hot path; (4) minimal dependencies and a small IR-tr
   separate-environment Turing.jl suite.
 - `docs/src/` — `index.md` (user) and `internals.md` (documented-internals docstring index).
 
-## Working Conventions
+## Working conventions
 
-- **Lives on `Core.Compiler` internals**, unstable across Julia versions — the most fragile
-  part of the codebase. Guard version-specific behaviour with `@static if VERSION ...` (e.g.
-  `set_valid_world!`, the `get_mi` shim); test on every supported version. The `[compat]`
-  range (`~1.10.8, 1.11.6`) and the CI matrix (`.github/workflows/CI.yml`) move together.
+- Compiler internals are the most fragile part of the codebase. Use compile-time version or
+  feature guards where their representation differs. Treat `Project.toml`, the CI workflows,
+  and guards or warnings in the source as authoritative for supported Julia versions; keep
+  them aligned and run every configured test line when support changes.
 - Fix IR problems by making the transform correct, not by special-casing the public API.
-  `transformation.jl`/`refelim.jl` are the single source of truth for the resumable IR.
-- `produce` and `get_taped_globals(::Type)` are **reserved statements**, not real functions:
-  `produce` is `@noinline` with a dummy side-effect so the transform can find/rewrite it (it
-  never runs under `consume`). Don't "optimise away" what resists inlining/constant-folding.
-- Concrete `Core.Compiler` types (`IRCode`, `SSAValue`, …) in the transform layer are
-  load-bearing, not over-constraint; annotate as specifically as dispatch requires.
+  Make resumable-IR changes in `transformation.jl` or `refelim.jl`.
+- `produce` is an `@noinline` marker function with a dummy side effect so direct calls remain
+  visible to the transform. Calls through another function suspend only when the callee is
+  recognised by `might_produce` or `@might_produce`; otherwise `produce` executes as an
+  ordinary call and does not suspend. `get_taped_globals(::Type)` is a normal `@noinline`
+  lookup of task-local storage populated by `consume`, not a transformed statement. Do not
+  remove the annotations or dummy side effect without replacing their purpose.
+- Concrete `Core.Compiler` types (`IRCode`, `SSAValue`, …) in the transform layer intentionally
+  constrain dispatch. Generalise them only when callers require it and the IR tests cover it.
 - **Workflow for any bug fix or new feature**: investigate → root-cause → understand the big
   picture → *verify the fix before committing to it*. Reproduce with an MWE, inspect derived IR
   (`Libtask.generate_ir`), and confirm the hypothesis by temporarily editing or monkey-patching
   (e.g. `@eval`-ing a replacement method, hacking the local checkout) until the MWE behaves —
   only then write the real change. Don't edit the transform on a guess. Prefer targeted fixes
-  over new helpers or refactors; run `minimise` before committing.
+  over new helpers or refactors; reduce the reproducer, regression test, and diff before
+  committing.
 - Write clear, local errors for unsupported inputs (naked `produce`, unhandled control flow) —
   a clear `ArgumentError` at construction beats a confusing failure in compiled IR.
-- Internals may change freely; exports, the `produce`/`consume`/`copy` contract, and names in
-  `docs/src/internals.md` need tests, docs, and stable errors — update docs when they change.
-- Format with JuliaFormatter, **blue** style: `julia -e 'using JuliaFormatter; format(".")'`.
+- Internals may change freely. Public exports and the `produce`/`consume`/`copy` contract need
+  tests, documentation, and stable errors. Keep `docs/src/internals.md` synchronized with
+  documented internal names.
+- Match the formatter and style configured by `.github/workflows/Format.yml` and
+  `.JuliaFormatter.toml`. Install the configured formatter in an isolated environment rather
+  than relying on a global installation.
 
 ## Concurrency
 
 - `build_callable` is serialized under `build_callable_lock` (`ReentrantLock`) — deliberate:
   IR derivation mutates a shared `ID` counter (`seed_id!`/`ID()`) and the `MistyClosure` cache,
-  and concurrent derivation segfaulted (#227). Keep all ID generation and cache mutation inside
-  this lock; don't add a second IR-deriving code path outside it.
-- `bbcode.jl` indexes its `ID` counter by `Threads.threadid()` — suspect (task migration makes
-  IDs unstable); the lock, not `threadid()`, is what makes it safe today.
-- `copy(::TapedTask)` is `deepcopy`: the copy must share **no** mutable state (`Ref`s,
-  position). Any change to state storage must keep this — test that mutating a copy doesn't
-  affect the source.
+  and concurrent production derivation segfaulted (#227). Keep every production IR-deriving
+  path and cache mutation inside this lock.
+- Debugging and direct `BasicBlockCode` utilities are outside this concurrency guarantee and
+  must not run concurrently with another ID-generating path unless they acquire the same
+  lock. Treat ID generation as one critical section rather than relying on the counter's
+  implementation for uniqueness.
+- `copy(::TapedTask)` is `deepcopy`: the copy must share no task-owned mutable state, including
+  captured `Ref`s and the position counter. Any change to state storage must preserve this;
+  test that mutating a copy does not affect the source.
 
 ## Testing
 
 - MWE first, then the smallest focused test, then broader groups. Prefer extending existing
-  `Testcase`s over adding new ones; prune with `minimise`.
+  `Testcase`s over adding new ones; reduce the final regression to the smallest case that
+  still fails without the fix.
 - Register behaviour as `TestUtils.Testcase`s where possible — the driver iterates the task,
   `copy`s after every iteration, and checks every copy resumes to the same result sequence
   (plus optional allocation flags), exercising the copy/resume contract for free. Reserve
   bespoke `test/` code for what the driver can't express.
 - Cover control-flow variety (branches, loops, nested produce, exception regions) and varied
   value types. Bug fixes land with a focused regression test; version/world-age fixes get an
-  isolated direct test. Check `consume` allocations (`@allocated` post-warmup) and stability
-  (`@code_warntype`) for perf-sensitive paths.
+  isolated direct test. Use the existing post-warmup allocation helper and `@code_warntype`
+  for performance-sensitive paths.
 - Never disable tests or weaken perf/allocation assertions to get CI green — ask first.
 - `test/integration/turing/` runs in its own environment and is part of the contract: transform
   or semantics changes may need updates there even when core tests pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
 license = "MIT"
 desc = "Tape based task copying in Turing"
 repo = "https://github.com/TuringLang/Libtask.jl.git"
-version = "0.9.18"
+version = "0.9.19"
 
 [deps]
 MistyClosures = "dbe65cb8-6be2-42dd-bbc5-4196aaced4f4"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
 license = "MIT"
 desc = "Tape based task copying in Turing"
 repo = "https://github.com/TuringLang/Libtask.jl.git"
-version = "0.9.19"
+version = "0.9.18"
 
 [deps]
 MistyClosures = "dbe65cb8-6be2-42dd-bbc5-4196aaced4f4"

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -5,11 +5,13 @@ Libtask.generate_ir
 Libtask.produce_value
 Libtask.is_produce_stmt
 Libtask.stmt_might_produce
+Libtask.assert_can_handle_control_flow
 Libtask.inc_args
 Libtask.get_type
 Libtask._typeof
 Libtask.replace_captures
 Libtask.BasicBlockCode
+Libtask.BasicBlockCode.IDEnterNode
 Libtask.opaque_closure
 Libtask.misty_closure
 Libtask.optimise_ir!

--- a/src/bbcode.jl
+++ b/src/bbcode.jl
@@ -23,6 +23,8 @@ export ID,
     IDPhiNode,
     IDGotoNode,
     IDGotoIfNot,
+    IDEnterNode,
+    remake_enter,
     Switch,
     BBlock,
     phi_nodes,
@@ -86,6 +88,47 @@ struct IDGotoIfNot
 end
 
 Base.copy(node::IDGotoIfNot) = IDGotoIfNot(copy(node.cond), copy(node.dest))
+
+"""
+    IDEnterNode
+
+The `ID`-based analogue of the IR node which marks the start of a `try` block. It plays the
+same role for exception-handling control flow that `IDGotoNode` plays for
+unconditional branches: `catch_id` refers to the catch block by its `ID`, so that the
+reference survives block splitting / re-ordering during the IR transformation. `catch_id` is
+`nothing` for a scope-only `enter` that has no catch block (`Core.EnterNode` with
+`catch_dest == 0`, e.g. the dynamic-scope `enter` emitted by `Base.ScopedValues.@with`).
+
+This is the single representation used throughout `BBCode`, regardless of Julia version: it
+is produced from a `Core.EnterNode` on Julia versions where that type exists (1.11+) and
+from an `Expr(:enter, ...)` on Julia 1.10, and converted back to the version-appropriate
+node when lowering to `IRCode`. The optional `scope` field mirrors `Core.EnterNode`'s
+optional `scope`.
+"""
+struct IDEnterNode
+    catch_id::Union{ID,Nothing}
+    scope::Any
+    IDEnterNode(catch_id::Union{ID,Nothing}) = new(catch_id)
+    IDEnterNode(catch_id::Union{ID,Nothing}, @nospecialize(scope)) = new(catch_id, scope)
+end
+
+"""
+    remake_enter(node::IDEnterNode, catch_id, scope_map=identity)
+
+Rebuild `node` with catch block `catch_id`, mapping its `scope` (if present) through
+`scope_map`. Centralises the optional-`scope` handling that the transformations of an
+`IDEnterNode` (`copy`, `replace_ids`, `inc_args`, catch-edge relabelling) would otherwise
+each repeat.
+"""
+function remake_enter(node::IDEnterNode, catch_id::Union{ID,Nothing}, scope_map=identity)
+    return if isdefined(node, :scope)
+        IDEnterNode(catch_id, scope_map(node.scope))
+    else
+        IDEnterNode(catch_id)
+    end
+end
+
+Base.copy(node::IDEnterNode) = remake_enter(node, node.catch_id)
 
 struct Switch
     conds::Vector{Any}
@@ -192,20 +235,35 @@ compute_all_successors(ir::BBCode)::Dict{ID,Vector{ID}} = _compute_all_successor
         is_final_block = n == length(blks)
         t = terminator(blk)
         if t === nothing
-            return is_final_block ? ID[] : ID[blks[n + 1].id]
+            normal_succs = is_final_block ? ID[] : ID[blks[n + 1].id]
         elseif t isa IDGotoNode
-            return [t.label]
+            normal_succs = [t.label]
         elseif t isa IDGotoIfNot
-            return is_final_block ? ID[t.dest] : ID[t.dest, blks[n + 1].id]
+            normal_succs = is_final_block ? ID[t.dest] : ID[t.dest, blks[n + 1].id]
         elseif t isa ReturnNode
-            return ID[]
+            normal_succs = ID[]
         elseif t isa Switch
-            return vcat(t.dests, t.fallthrough_dest)
+            normal_succs = vcat(t.dests, t.fallthrough_dest)
         else
             error("Unhandled terminator $t")
         end
+        # A block containing an `IDEnterNode` has an extra (exception) edge to its catch
+        # block, in addition to whatever its terminator dictates. Unlike a terminator, the
+        # `enter` may sit anywhere in the block, so we scan for it explicitly.
+        return _append_catch_edge(normal_succs, blk)
     end
     return Dict{ID,Vector{ID}}((b.id, succ) for (b, succ) in zip(blks, succs))
+end
+
+function _append_catch_edge(succs::Vector{ID}, blk::BBlock)
+    for inst in blk.insts
+        if inst.stmt isa IDEnterNode
+            catch_id = inst.stmt.catch_id
+            # A scope-only `enter` (`catch_id === nothing`) has no catch block, hence no edge.
+            catch_id isa ID && !in(catch_id, succs) && push!(succs, catch_id)
+        end
+    end
+    return succs
 end
 
 function compute_all_predecessors(ir::BBCode)::Dict{ID,Vector{ID}}
@@ -288,8 +346,17 @@ function __line_numbers_to_block_numbers!(insts::Vector{Any}, cfg::CC.CFG)
                 Int32[CC.block_for_inst(cfg, Int(edge)) for edge in stmt.edges], stmt.values
             )
         elseif Meta.isexpr(stmt, :enter)
-            stmt.args[1] = CC.block_for_inst(cfg, stmt.args[1]::Int)
+            # `catch_dest == 0` marks a scope-only `enter` with no catch block; leave it.
+            if stmt.args[1]::Int != 0
+                stmt.args[1] = CC.block_for_inst(cfg, stmt.args[1]::Int)
+            end
             insts[i] = stmt
+        else
+            @static if isdefined(Core, :EnterNode)
+                if isa(stmt, Core.EnterNode) && stmt.catch_dest != 0
+                    insts[i] = Core.EnterNode(stmt, CC.block_for_inst(cfg, stmt.catch_dest))
+                end
+            end
         end
     end
     return insts
@@ -349,6 +416,12 @@ function _ssa_to_ids(d::SSAToIdDict, x::PhiNode)
 end
 _ssa_to_ids(d::SSAToIdDict, x::GotoNode) = x
 _ssa_to_ids(d::SSAToIdDict, x::GotoIfNot) = GotoIfNot(get(d, x.cond, x.cond), x.dest)
+@static if isdefined(Core, :EnterNode)
+    function _ssa_to_ids(d::SSAToIdDict, x::Core.EnterNode)
+        isdefined(x, :scope) || return x
+        return Core.EnterNode(x.catch_dest, get(d, x.scope, x.scope))
+    end
+end
 
 function _block_nums_to_ids(insts::InstVector, cfg::CC.CFG)::Tuple{Vector{ID},InstVector}
     ids = map(_ -> ID(), cfg.blocks)
@@ -364,7 +437,23 @@ function _block_num_to_ids(d::BlockNumToIdDict, x::PhiNode)
 end
 _block_num_to_ids(d::BlockNumToIdDict, x::GotoNode) = IDGotoNode(d[x.label])
 _block_num_to_ids(d::BlockNumToIdDict, x::GotoIfNot) = IDGotoIfNot(x.cond, d[x.dest])
+function _block_num_to_ids(d::BlockNumToIdDict, x::Expr)
+    # On Julia 1.10 a `try` block begins with `Expr(:enter, catch_block_number)`; a
+    # `catch_block_number` of 0 is a scope-only `enter` with no catch block.
+    if Meta.isexpr(x, :enter)
+        catch_id = x.args[1]::Int == 0 ? nothing : d[x.args[1]::Int]
+        return IDEnterNode(catch_id)
+    end
+    return x
+end
 _block_num_to_ids(d::BlockNumToIdDict, x) = x
+@static if isdefined(Core, :EnterNode)
+    function _block_num_to_ids(d::BlockNumToIdDict, x::Core.EnterNode)
+        # `catch_dest == 0` is a scope-only `enter` (no catch block); record `nothing`.
+        catch_id = x.catch_dest == 0 ? nothing : d[x.catch_dest]
+        return isdefined(x, :scope) ? IDEnterNode(catch_id, x.scope) : IDEnterNode(catch_id)
+    end
+end
 
 # A map from IDs to IDs; useful when generically replacing IDs in BBCode statements
 const IdToIdDict = Dict{ID,ID}
@@ -392,6 +481,9 @@ end
 replace_ids(d::IdToIdDict, x::IDGotoNode) = x
 function replace_ids(d::IdToIdDict, x::IDGotoIfNot)
     return IDGotoIfNot(get(d, x.cond, x.cond), get(d, x.dest, x.dest))
+end
+function replace_ids(d::IdToIdDict, x::IDEnterNode)
+    return remake_enter(x, get(d, x.catch_id, x.catch_id), s -> get(d, s, s))
 end
 function replace_ids(d::IdToIdDict, x::Switch)
     new_conds = Vector{Any}(undef, length(x.conds))
@@ -510,6 +602,24 @@ function _to_ssas(d::Dict, x::IDPhiNode)
 end
 _to_ssas(d::Dict, x::IDGotoNode) = GotoNode(d[x.label].id)
 _to_ssas(d::Dict, x::IDGotoIfNot) = GotoIfNot(get(d, x.cond, x.cond), d[x.dest].id)
+@static if isdefined(Core, :EnterNode)
+    # `d[x.catch_id].id` is the SSAValue index of the catch block's first statement; it is
+    # mapped to a block number later by `__line_numbers_to_block_numbers!`, exactly as for
+    # the destination of an `IDGotoNode`. A scope-only `enter` (`catch_id === nothing`) maps
+    # back to `catch_dest == 0`.
+    function _to_ssas(d::Dict, x::IDEnterNode)
+        dest = x.catch_id === nothing ? 0 : d[x.catch_id].id
+        return if isdefined(x, :scope)
+            Core.EnterNode(dest, get(d, x.scope, x.scope))
+        else
+            Core.EnterNode(dest)
+        end
+    end
+else
+    function _to_ssas(d::Dict, x::IDEnterNode)
+        return Expr(:enter, x.catch_id === nothing ? 0 : d[x.catch_id].id)
+    end
+end
 
 function _remove_double_edges(ir::BBCode)
     new_blks = map(enumerate(ir.blocks)) do (n, blk)
@@ -607,6 +717,9 @@ end
 function _find_id_uses!(d::Dict{ID,Bool}, x::ReturnNode)
     return isdefined(x, :val) && in(x.val, keys(d)) && setindex!(d, true, x.val)
 end
+function _find_id_uses!(d::Dict{ID,Bool}, x::IDEnterNode)
+    return isdefined(x, :scope) && in(x.scope, keys(d)) && setindex!(d, true, x.scope)
+end
 _find_id_uses!(d::Dict{ID,Bool}, x::QuoteNode) = nothing
 _find_id_uses!(d::Dict{ID,Bool}, x) = nothing
 
@@ -642,6 +755,14 @@ end
 
 function Base.show(io::IO, node::IDGotoNode)
     return print(io, "goto ", _block_str(node.label))
+end
+
+function Base.show(io::IO, node::IDEnterNode)
+    print(
+        io, "enter ", node.catch_id === nothing ? "(no catch)" : _block_str(node.catch_id)
+    )
+    isdefined(node, :scope) && print(io, " (scope ", _val_str(node.scope), ")")
+    return nothing
 end
 
 function Base.show(io::IO, node::IDGotoIfNot)

--- a/src/bbcode.jl
+++ b/src/bbcode.jl
@@ -29,6 +29,7 @@ export ID,
     BBlock,
     phi_nodes,
     terminator,
+    is_implicit_terminator,
     insert_before_terminator!,
     collect_stmts,
     compute_all_predecessors,
@@ -92,18 +93,8 @@ Base.copy(node::IDGotoIfNot) = IDGotoIfNot(copy(node.cond), copy(node.dest))
 """
     IDEnterNode
 
-The `ID`-based analogue of the IR node which marks the start of a `try` block. It plays the
-same role for exception-handling control flow that `IDGotoNode` plays for
-unconditional branches: `catch_id` refers to the catch block by its `ID`, so that the
-reference survives block splitting / re-ordering during the IR transformation. `catch_id` is
-`nothing` for a scope-only `enter` that has no catch block (`Core.EnterNode` with
-`catch_dest == 0`, e.g. the dynamic-scope `enter` emitted by `Base.ScopedValues.@with`).
-
-This is the single representation used throughout `BBCode`, regardless of Julia version: it
-is produced from a `Core.EnterNode` on Julia versions where that type exists (1.11+) and
-from an `Expr(:enter, ...)` on Julia 1.10, and converted back to the version-appropriate
-node when lowering to `IRCode`. The optional `scope` field mirrors `Core.EnterNode`'s
-optional `scope`.
+Represent an exception or dynamic-scope `enter` using stable block IDs. `catch_id` is
+`nothing` for a scope-only `enter`; the optional `scope` field mirrors `Core.EnterNode`.
 """
 struct IDEnterNode
     catch_id::Union{ID,Nothing}
@@ -112,14 +103,6 @@ struct IDEnterNode
     IDEnterNode(catch_id::Union{ID,Nothing}, @nospecialize(scope)) = new(catch_id, scope)
 end
 
-"""
-    remake_enter(node::IDEnterNode, catch_id, scope_map=identity)
-
-Rebuild `node` with catch block `catch_id`, mapping its `scope` (if present) through
-`scope_map`. Centralises the optional-`scope` handling that the transformations of an
-`IDEnterNode` (`copy`, `replace_ids`, `inc_args`, catch-edge relabelling) would otherwise
-each repeat.
-"""
 function remake_enter(node::IDEnterNode, catch_id::Union{ID,Nothing}, scope_map=identity)
     return if isdefined(node, :scope)
         IDEnterNode(catch_id, scope_map(node.scope))
@@ -142,12 +125,19 @@ end
 
 const Terminator = Union{Switch,IDGotoIfNot,IDGotoNode,ReturnNode}
 
+is_implicit_terminator(x) = x isa IDEnterNode || Meta.isexpr(x, :leave)
+
 mutable struct BBlock
     id::ID
     inst_ids::Vector{ID}
     insts::InstVector
     function BBlock(id::ID, inst_ids::Vector{ID}, insts::InstVector)
         @assert length(inst_ids) == length(insts)
+        if length(insts) > 1
+            @assert all(
+                inst -> !is_implicit_terminator(inst.stmt), @view(insts[begin:(end - 1)])
+            ) "`enter` and `:leave` must terminate their basic block"
+        end
         return new(id, inst_ids, insts)
     end
 end
@@ -247,21 +237,16 @@ compute_all_successors(ir::BBCode)::Dict{ID,Vector{ID}} = _compute_all_successor
         else
             error("Unhandled terminator $t")
         end
-        # A block containing an `IDEnterNode` has an extra (exception) edge to its catch
-        # block, in addition to whatever its terminator dictates. Unlike a terminator, the
-        # `enter` may sit anywhere in the block, so we scan for it explicitly.
+        # `enter` has a catch edge in addition to its implicit fallthrough.
         return _append_catch_edge(normal_succs, blk)
     end
     return Dict{ID,Vector{ID}}((b.id, succ) for (b, succ) in zip(blks, succs))
 end
 
 function _append_catch_edge(succs::Vector{ID}, blk::BBlock)
-    for inst in blk.insts
-        if inst.stmt isa IDEnterNode
-            catch_id = inst.stmt.catch_id
-            # A scope-only `enter` (`catch_id === nothing`) has no catch block, hence no edge.
-            catch_id isa ID && !in(catch_id, succs) && push!(succs, catch_id)
-        end
+    enter = blk.insts[end].stmt
+    if enter isa IDEnterNode && enter.catch_id isa ID && !in(enter.catch_id, succs)
+        push!(succs, enter.catch_id)
     end
     return succs
 end

--- a/src/copyable_task.jl
+++ b/src/copyable_task.jl
@@ -138,7 +138,8 @@ function generate_ir(stage::Symbol, fargs...; kwargs...)
     seed_id!()
     original_bb = BBCode(original_ir)
     stage == :input_bb && return original_bb
-    transformed_bb, refs, _ = derive_copyable_task_ir(BBCode(original_ir))
+    assert_can_handle_control_flow(original_bb)
+    transformed_bb, refs, _ = derive_copyable_task_ir(original_bb)
     stage == :transformed_bb && return transformed_bb
     topt_bb, refs = eliminate_refs(transformed_bb, refs)
     stage == :optimised_bb && return topt_bb
@@ -184,7 +185,10 @@ function build_callable(sig::Type{<:Tuple})
             ir = ir_results[1][1]
             # Check whether this is a varargs call.
             isva = which(sig).isva
-            bb, refs, types = derive_copyable_task_ir(BBCode(ir))
+            input_bb = BBCode(ir)
+            # Reject `try` / `catch` control flow that we cannot faithfully reproduce.
+            assert_can_handle_control_flow(input_bb)
+            bb, refs, types = derive_copyable_task_ir(input_bb)
             bb, refs = eliminate_refs(bb, refs)
             unoptimised_ir = IRCode(bb)
             @static if VERSION > v"1.12-"
@@ -362,6 +366,25 @@ julia> consume(t)
 
 `Int`s have been used here, but it is permissible to set the value returned by
 [`Libtask.get_taped_globals`](@ref) to anything you like.
+
+## Control flow and `try` / `catch`
+
+Ordinary control flow -- branches, loops, and so on -- is fully supported inside a
+`TapedTask`. `try` / `catch` / `finally` blocks are supported with some restrictions, because
+a `TapedTask` suspends at each [`Libtask.produce`](@ref) and resumes later, whereas the
+exception-handler state set up by a `try` does not survive such a suspension:
+
+  - `try` / `catch` / `finally` is supported on Julia 1.12 and later. On earlier versions a
+    function containing one is rejected with an informative error.
+  - A [`Libtask.produce`](@ref) must not be reachable while an exception handler is active
+    (i.e. inside a `try` body, or inside a `catch` before the block finishes). Such a
+    `produce` is rejected. Capture any value you need inside the block and call
+    [`Libtask.produce`](@ref) *after* it instead.
+  - A `try` / `catch` whose result is a value used after the block (code that lowers to
+    `UpsilonNode` / `PhiCNode` IR nodes) is not yet supported, and is rejected.
+
+In every unsupported case a clear `ArgumentError` is thrown when the `TapedTask` is
+constructed, rather than producing incorrect results.
 
 # Implementation Notes
 

--- a/src/copyable_task.jl
+++ b/src/copyable_task.jl
@@ -138,7 +138,6 @@ function generate_ir(stage::Symbol, fargs...; kwargs...)
     seed_id!()
     original_bb = BBCode(original_ir)
     stage == :input_bb && return original_bb
-    assert_can_handle_control_flow(original_bb)
     transformed_bb, refs, _ = derive_copyable_task_ir(original_bb)
     stage == :transformed_bb && return transformed_bb
     topt_bb, refs = eliminate_refs(transformed_bb, refs)
@@ -185,10 +184,7 @@ function build_callable(sig::Type{<:Tuple})
             ir = ir_results[1][1]
             # Check whether this is a varargs call.
             isva = which(sig).isva
-            input_bb = BBCode(ir)
-            # Reject `try` / `catch` control flow that we cannot faithfully reproduce.
-            assert_can_handle_control_flow(input_bb)
-            bb, refs, types = derive_copyable_task_ir(input_bb)
+            bb, refs, types = derive_copyable_task_ir(BBCode(ir))
             bb, refs = eliminate_refs(bb, refs)
             unoptimised_ir = IRCode(bb)
             @static if VERSION > v"1.12-"
@@ -367,21 +363,19 @@ julia> consume(t)
 `Int`s have been used here, but it is permissible to set the value returned by
 [`Libtask.get_taped_globals`](@ref) to anything you like.
 
-## Control flow and `try` / `catch`
+## Exception handling and dynamic scopes
 
 Ordinary control flow -- branches, loops, and so on -- is fully supported inside a
-`TapedTask`. `try` / `catch` / `finally` blocks are supported with some restrictions, because
-a `TapedTask` suspends at each [`Libtask.produce`](@ref) and resumes later, whereas the
-exception-handler state set up by a `try` does not survive such a suspension:
+`TapedTask`. Exception handling and `Base.ScopedValues.@with` are supported with some
+restrictions because their runtime state does not survive when [`Libtask.produce`](@ref)
+suspends the task:
 
-  - `try` / `catch` / `finally` is supported on Julia 1.12 and later. On earlier versions a
-    function containing one is rejected with an informative error.
-  - A [`Libtask.produce`](@ref) must not be reachable while an exception handler is active
-    (i.e. inside a `try` body, or inside a `catch` before the block finishes). Such a
-    `produce` is rejected. Capture any value you need inside the block and call
-    [`Libtask.produce`](@ref) *after* it instead.
-  - A `try` / `catch` whose result is a value used after the block (code that lowers to
-    `UpsilonNode` / `PhiCNode` IR nodes) is not yet supported, and is rejected.
+  - `try` / `catch` / `finally` and `Base.ScopedValues.@with` are supported on Julia 1.12 and
+    later. A function containing one is rejected on earlier versions.
+  - [`Libtask.produce`](@ref) must not be reachable while an exception handler or dynamic
+    scope is active. Capture the required value within the region and call `produce` after it.
+  - Some catch handlers that read local values lower to `UpsilonNode` / `PhiCNode`. These IR
+    nodes are not yet supported and are rejected.
 
 In every unsupported case a clear `ArgumentError` is thrown when the `TapedTask` is
 constructed, rather than producing incorrect results.

--- a/src/transformation.jl
+++ b/src/transformation.jl
@@ -27,17 +27,24 @@ function is_produce_stmt(x)::Bool
 end
 
 """
-    stmt_might_produce(x, ret_type::Type)::Bool
+    stmt_might_produce(x, ret_type::Type; assume_returns::Bool=false)::Bool
 
 `true` if `x` might contain a call to `produce`, and `false` otherwise.
+
+By default, a statement whose inferred return type is `Union{}` is assumed not to produce:
+it terminates in an unusual fashion (e.g. by throwing), so the splitting logic does not need
+to treat it as a possible `produce` site. Pass `assume_returns=true` to skip this
+short-circuit -- a call which produces *and then* throws still produces, which matters when
+deciding whether a `produce` could suspend inside an exception handler (see
+[`assert_can_handle_control_flow`](@ref)).
 """
-function stmt_might_produce(x, ret_type::Type)::Bool
+function stmt_might_produce(x, ret_type::Type; assume_returns::Bool=false)::Bool
 
     # Statement will terminate in an unusual fashion, so don't bother recursing.
     # This isn't _strictly_ correct (there could be a `produce` statement before the
-    # `throw` call is hit), but this seems unlikely to happen in practice. If it does, the
-    # user should get a sensible error message anyway.
-    ret_type == Union{} && return false
+    # `throw` call is hit), but for the splitting logic this seems unlikely to happen in
+    # practice. Exception-handler safety analysis sets `assume_returns` to be exact here.
+    !assume_returns && ret_type == Union{} && return false
 
     # Statement will terminate in the usual fashion, so _do_ bother recusing.
     is_produce_stmt(x) && return true
@@ -105,6 +112,7 @@ end
 inc_args(::Nothing) = nothing
 inc_args(x::GlobalRef) = x
 inc_args(x::Core.PiNode) = Core.PiNode(__inc(x.val), __inc(x.typ))
+inc_args(x::IDEnterNode) = remake_enter(x, x.catch_id, __inc)
 
 __inc(x::Argument) = Argument(x.n + 1)
 __inc(x) = x
@@ -146,6 +154,170 @@ function get_type(::TypeInfo, x::Expr)
     return error("Unrecognised expression $x found in argument slot.")
 end
 
+"""
+    assert_can_handle_control_flow(ir::BBCode)
+
+Check that any `try` / `catch` / `finally` control flow in `ir` is something a `TapedTask`
+can faithfully reproduce, throwing an informative `ArgumentError` otherwise.
+
+A `TapedTask` is a suspend/resume state machine: a `produce` returns from the underlying
+`OpaqueClosure`, and the next `consume` re-enters it and jumps straight to the resumption
+point. The exception-handler frame established by an `enter` lives on that closure's call
+stack, so it does not survive a suspend/resume boundary. This splits exception handling
+into three cases:
+
+  - Safe — every `enter` and its matching `pop_exception` / `leave` execute within a single
+    `consume` call (no `produce` suspends while a handler is active). The handler frame is
+    created and torn down within one closure invocation, so the control flow can be
+    reproduced directly. This is the case we support.
+
+  - Unsafe — a `produce` can suspend while a handler is active (a `produce` in the `try`
+    body, or in the `catch` before `pop_exception`). On resume the handler frame is gone and
+    the stale exception token would be used, so this cannot work without re-architecting how
+    task state is captured. This is the case in issue #194's MWE; we reject it here.
+
+  - Already fine — a `try` / `catch` the compiler can prove never throws is optimised away
+    before we ever see it, so it generates no exception IR and needs no handling.
+
+The design decision is therefore to support the safe subset and reject the unsafe subset
+with a clear error rather than miscompile it. Value-carrying `catch` blocks (which lower to
+`UpsilonNode` / `PhiCNode`) are not yet supported even when safe, and are rejected too; see
+the follow-up tracked alongside issue #194.
+
+Detection works directly on the `BBCode`, which represents every `enter` (`Core.EnterNode`
+on Julia 1.11+, `Expr(:enter)` on Julia 1.10) uniformly as an `IDEnterNode` and
+already carries the exception (catch) edges in its CFG. We run a forward data-flow pass over
+the blocks tracking how many exception-handler frames are live; a `produce` (or a call which
+might `produce`) reached while at least one frame is live is unsafe. This is version-
+agnostic and handles `try` / `catch` inside loops, unlike `Core.Compiler.compute_trycatch`
+whose shape and handler-region marking differ across the supported Julia versions.
+"""
+function assert_can_handle_control_flow(ir::BBCode)
+    # Single pass to detect the start of a `try` (`IDEnterNode`) and whether a value flows out
+    # of one (`UpsilonNode` / `PhiCNode`, which only arise from exception handling).
+    has_enter = false
+    has_value_carrying = false
+    for blk in ir.blocks, inst in blk.insts
+        stmt = inst.stmt
+        stmt isa IDEnterNode && (has_enter = true)
+        (stmt isa Core.UpsilonNode || stmt isa Core.PhiCNode) && (has_value_carrying = true)
+    end
+
+    # No exception-handling control flow at all (the common case).
+    has_enter || return nothing
+
+    # Before Julia 1.12 the compiler passes we run over the derived IR (constant propagation,
+    # inlining, codegen) do not reliably handle exception-handling nodes -- depending on the
+    # control-flow shape they either error or miscompile to a crash. Rather than risk that,
+    # reject `try` / `catch` outright on those versions with a clear message. From 1.12 the
+    # compiler handles these nodes and the safe subset below is supported.
+    @static if VERSION < v"1.12-"
+        throw(ArgumentError(_TRY_CATCH_VERSION_MSG))
+    end
+
+    # Not-yet-supported case: a value defined in a `try` / `catch` and used afterwards lowers
+    # to `UpsilonNode` / `PhiCNode`, which the transformation does not yet handle.
+    has_value_carrying && throw(ArgumentError(_VALUE_CARRYING_CATCH_MSG))
+
+    # Unsafe case: a `produce` (or a call which might `produce`) which can run while an
+    # exception-handler frame is live cannot be reproduced across a suspend/resume boundary.
+    # Compute, by forward data-flow to a fixed point, the number of handler frames live on
+    # entry to each block, then scan for an offending `produce`.
+    handler_depth_in = _handler_depth_on_entry(ir)
+    for blk in ir.blocks
+        depth = handler_depth_in[blk.id]
+        for inst in blk.insts
+            stmt = inst.stmt
+            if depth > 0 && (
+                is_produce_stmt(stmt) ||
+                stmt_might_produce(stmt, CC.widenconst(inst.type); assume_returns=true)
+            )
+                throw(ArgumentError(_PRODUCE_IN_HANDLER_MSG))
+            end
+            depth = _apply_handler_delta(depth, stmt)
+        end
+    end
+    return nothing
+end
+
+# Number of exception-handler frames opened (`enter`) minus closed (`leave` /
+# `:pop_exception`) by `stmt`, applied to a running `depth` (clamped at zero).
+function _apply_handler_delta(depth::Int, @nospecialize(stmt))
+    stmt isa IDEnterNode && return depth + 1
+    if Meta.isexpr(stmt, :leave)
+        # On Julia 1.12+ (the only versions on which this data-flow runs -- earlier versions
+        # reject `try` / `catch` before reaching here) a `:leave` lists one enter token per
+        # frame it closes, so the number of frames closed is the token count. The integer
+        # form `Expr(:leave, n)` is the older lowering and is handled defensively only.
+        n = if length(stmt.args) == 1 && stmt.args[1] isa Integer
+            Int(stmt.args[1])
+        else
+            count(a -> a !== nothing, stmt.args)
+        end
+        return max(depth - n, 0)
+    end
+    Meta.isexpr(stmt, :pop_exception) && return max(depth - 1, 0)
+    return depth
+end
+
+# Forward data-flow: the number of handler frames live on entry to each block. At a join we
+# take the maximum over predecessors -- structured exception handling keeps the depth equal
+# across merging paths, and the maximum is the conservative (never-under-count) choice.
+function _handler_depth_on_entry(ir::BBCode)
+    preds = compute_all_predecessors(ir)
+    depth_in = Dict{ID,Int}(blk.id => 0 for blk in ir.blocks)
+    depth_out = Dict{ID,Int}(blk.id => 0 for blk in ir.blocks)
+    changed = true
+    while changed
+        changed = false
+        for blk in ir.blocks
+            new_in = isempty(preds[blk.id]) ? 0 : maximum(p -> depth_out[p], preds[blk.id])
+            d = new_in
+            for inst in blk.insts
+                d = _apply_handler_delta(d, inst.stmt)
+            end
+            if new_in != depth_in[blk.id] || d != depth_out[blk.id]
+                depth_in[blk.id] = new_in
+                depth_out[blk.id] = d
+                changed = true
+            end
+        end
+    end
+    return depth_in
+end
+
+const _PRODUCE_IN_HANDLER_MSG = """
+    `TapedTask` does not support a `produce` inside a `try` / `catch` / `finally` block \
+    (including a `produce` in the `try` body or in the `catch` before the block finishes). \
+    A `produce` suspends the task, but the exception-handler frame set up by the `try` \
+    cannot be restored when the task is resumed, so this cannot be reproduced faithfully. \
+    Move the `produce` outside the `try` / `catch` block (for example, by capturing a value \
+    inside the block and calling `produce` after it). See \
+    https://github.com/TuringLang/Libtask.jl/issues/194 for details."""
+
+const _VALUE_CARRYING_CATCH_MSG = """
+    `TapedTask` does not yet support a `try` / `catch` / `finally` block that defines a \
+    value used after the block (such code lowers to `UpsilonNode` / `PhiCNode` IR nodes). \
+    `try` / `catch` blocks which do not feed a value into later code are supported. See \
+    https://github.com/TuringLang/Libtask.jl/issues/194 for details."""
+
+const _TRY_CATCH_VERSION_MSG = """
+    `TapedTask` only supports functions containing `try` / `catch` / `finally` blocks on \
+    Julia 1.12 or later; the Julia compiler does not reliably handle exception-handling IR \
+    in the derived task on earlier versions. Upgrade to Julia 1.12+, or rewrite the function \
+    to avoid `try` / `catch` (for example, by using explicit conditional checks). See \
+    https://github.com/TuringLang/Libtask.jl/issues/194 for details."""
+
+# `true` for statements which Julia's IR verifier treats as block-terminating but which
+# `BBCode` does not model as `Terminator`s, namely `IDEnterNode` (the start of a `try`) and
+# `Expr(:leave)` (the normal exit from a `try`). Both must remain the final statement of
+# their block, falling through to the next block (an `enter` additionally branches to its
+# catch block). We therefore neither append a `GotoNode` after them nor read their operands
+# from `Ref`s.
+function ends_block_implicitly(@nospecialize(stmt))
+    return stmt isa IDEnterNode || Meta.isexpr(stmt, :leave)
+end
+
 function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
     # The location from which all state can be retrieved. Since we're using `OpaqueClosure`s
     # to implement `TapedTask`s, this appears via the first argument.
@@ -175,6 +347,11 @@ function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
             stmt.stmt isa IDGotoIfNot && continue
             stmt.stmt === nothing && continue
             stmt.stmt isa ReturnNode && continue
+            # The token produced by an `enter` identifies a live exception-handler frame. It
+            # is meaningful only within a single execution of the closure (a `:leave` /
+            # `:pop_exception` consuming it always runs in the same `consume` call), so it is
+            # referenced directly as an SSA rather than round-tripped through a `Ref`.
+            stmt.stmt isa IDEnterNode && continue
             is_used_dict[id] || continue
             n += 1
             ssa_id_to_ref_index_map[id] = n
@@ -191,6 +368,17 @@ function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
     # necessary, but simplifies later stages of the pipeline, as discussed variously below.
     for (n, block) in enumerate(ir.blocks)
         if terminator(block) === nothing
+            # A block ending in an `IDEnterNode` or `:leave` is left as-is: Julia's IR
+            # verifier treats both as block-terminating, so they must remain the final
+            # statement of their block (each with an implicit fall-through edge to the next
+            # block; an `enter` additionally has its catch edge). We must not append a
+            # `GotoNode` after them. Such a block always falls through to post-`try` code, so
+            # it is never the structurally-final block; assert that so any future change which
+            # broke the invariant fails loudly here rather than silently dropping the edge.
+            if !isempty(block.insts) && ends_block_implicitly(block.insts[end].stmt)
+                @assert n < length(ir.blocks) "`enter` / `:leave` in the final basic block"
+                continue
+            end
             # Fall-through terminator, so next block in `ir.blocks` is the unique successor
             # block of `block`. Final block cannot have a fall-through terminator, so asking
             # for element `n + 1` is always going to be valid.
@@ -265,13 +453,23 @@ function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
     # 2. Construct a map between the ID of each block and the ID associated to its split.
     top_split_id_map = Dict{ID,ID}(b.id => x[1] for (b, x) in zip(ir.blocks, all_split_ids))
 
-    # 3. Update all `GotoNode`s and `GotoIfNot`s to refer to these new names.
+    # 3. Update all `GotoNode`s, `GotoIfNot`s, and `IDEnterNode` catch edges to refer to
+    #   these new names. An `enter`'s catch edge points at the catch block, which must be
+    #   re-pointed at that block's top split if it was split (a no-op when it was not).
     for block in ir.blocks
         t = terminator(block)
         if t isa IDGotoNode
             block.insts[end] = new_inst(IDGotoNode(top_split_id_map[t.label]))
         elseif t isa IDGotoIfNot
             block.insts[end] = new_inst(IDGotoIfNot(t.cond, top_split_id_map[t.dest]))
+        end
+        for (i, inst) in enumerate(block.insts)
+            s = inst.stmt
+            s isa IDEnterNode || continue
+            # A scope-only `enter` (`catch_id === nothing`) has no catch edge to relabel.
+            s.catch_id === nothing && continue
+            new_enter = remake_enter(s, top_split_id_map[s.catch_id])
+            block.insts[i] = new_inst(new_enter, inst.type)
         end
     end
 
@@ -483,6 +681,13 @@ function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
                     # do nothing -- we've already handled any `PhiNode`s.
                 elseif Meta.isexpr(stmt, :loopinfo)
                     push!(inst_pairs, (id, inst))
+                elseif Meta.isexpr(stmt, :pop_exception)
+                    # Pops the exception stack at the end of a `catch`. Its token argument is
+                    # the SSA produced by the corresponding `enter`; it is left as a direct
+                    # reference rather than read from a `Ref`. (An `IDEnterNode` and a
+                    # `:leave` are always block-terminating, so they are handled in the
+                    # terminator branch below rather than here.)
+                    push!(inst_pairs, (id, inst))
                 else
                     throw(error("Unhandled stmt $stmt of type $(typeof(stmt))"))
                 end
@@ -532,6 +737,31 @@ function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
                         push!(inst_pairs, (id, inst))
                     end
                 elseif stmt isa IDGotoNode
+                    push!(inst_pairs, (id, inst))
+                elseif stmt isa IDEnterNode
+                    # The `enter` terminates its block with an implicit fall-through to the
+                    # next block plus a catch edge (encoded in the `IDEnterNode` itself). It
+                    # must remain the final statement of the block, so we emit it without
+                    # appending a `GotoNode`; the fall-through is provided by block layout.
+                    # If the enter carries a `scope` that is an SSA, restore it from storage.
+                    if isdefined(stmt, :scope) && stmt.scope isa ID
+                        ref_ind = ssa_id_to_ref_index_map[stmt.scope]
+                        scope_id = ID()
+                        expr = Expr(:call, get_ref_at, refs_id, ref_ind)
+                        push!(inst_pairs, (scope_id, new_inst(expr)))
+                        push!(
+                            inst_pairs,
+                            (id, new_inst(IDEnterNode(stmt.catch_id, scope_id))),
+                        )
+                    else
+                        push!(inst_pairs, (id, inst))
+                    end
+                elseif Meta.isexpr(stmt, :leave)
+                    # The normal exit from a `try`. Like `enter`, it terminates its block (it
+                    # must be the block's final statement) and falls through to the next block
+                    # by layout, so we emit it without appending a `GotoNode`. Its token
+                    # operand is the SSA produced by the corresponding `enter` and is left as a
+                    # direct reference.
                     push!(inst_pairs, (id, inst))
                 else
                     error("Unexpected terminator $stmt")

--- a/src/transformation.jl
+++ b/src/transformation.jl
@@ -41,7 +41,7 @@ function stmt_might_produce(x, ret_type::Type; assume_returns::Bool=false)::Bool
     # checks whether it may suspend before terminating.
     !assume_returns && ret_type == Union{} && return false
 
-    # Statement will terminate in the usual fashion, so _do_ bother recusing.
+    # Statement will terminate in the usual fashion, so _do_ bother recursing.
     is_produce_stmt(x) && return true
     if Meta.isexpr(x, :invoke)
         mi_sig = get_mi(x.args[1]).specTypes

--- a/src/transformation.jl
+++ b/src/transformation.jl
@@ -32,18 +32,13 @@ end
 `true` if `x` might contain a call to `produce`, and `false` otherwise.
 
 By default, a statement whose inferred return type is `Union{}` is assumed not to produce:
-it terminates in an unusual fashion (e.g. by throwing), so the splitting logic does not need
-to treat it as a possible `produce` site. Pass `assume_returns=true` to skip this
-short-circuit -- a call which produces *and then* throws still produces, which matters when
-deciding whether a `produce` could suspend inside an exception handler (see
-[`assert_can_handle_control_flow`](@ref)).
+it terminates by throwing or otherwise cannot return to the caller. `assume_returns=true`
+keeps such calls eligible when checking whether they may suspend before terminating.
 """
 function stmt_might_produce(x, ret_type::Type; assume_returns::Bool=false)::Bool
 
-    # Statement will terminate in an unusual fashion, so don't bother recursing.
-    # This isn't _strictly_ correct (there could be a `produce` statement before the
-    # `throw` call is hit), but for the splitting logic this seems unlikely to happen in
-    # practice. Exception-handler safety analysis sets `assume_returns` to be exact here.
+    # The transform need not split after a call that cannot return. Safety analysis still
+    # checks whether it may suspend before terminating.
     !assume_returns && ret_type == Union{} && return false
 
     # Statement will terminate in the usual fashion, so _do_ bother recusing.
@@ -157,44 +152,14 @@ end
 """
     assert_can_handle_control_flow(ir::BBCode)
 
-Check that any `try` / `catch` / `finally` control flow in `ir` is something a `TapedTask`
-can faithfully reproduce, throwing an informative `ArgumentError` otherwise.
+Reject exception or dynamic-scope control flow that a `TapedTask` cannot reproduce.
 
-A `TapedTask` is a suspend/resume state machine: a `produce` returns from the underlying
-`OpaqueClosure`, and the next `consume` re-enters it and jumps straight to the resumption
-point. The exception-handler frame established by an `enter` lives on that closure's call
-stack, so it does not survive a suspend/resume boundary. This splits exception handling
-into three cases:
-
-  - Safe — every `enter` and its matching `pop_exception` / `leave` execute within a single
-    `consume` call (no `produce` suspends while a handler is active). The handler frame is
-    created and torn down within one closure invocation, so the control flow can be
-    reproduced directly. This is the case we support.
-
-  - Unsafe — a `produce` can suspend while a handler is active (a `produce` in the `try`
-    body, or in the `catch` before `pop_exception`). On resume the handler frame is gone and
-    the stale exception token would be used, so this cannot work without re-architecting how
-    task state is captured. This is the case in issue #194's MWE; we reject it here.
-
-  - Already fine — a `try` / `catch` the compiler can prove never throws is optimised away
-    before we ever see it, so it generates no exception IR and needs no handling.
-
-The design decision is therefore to support the safe subset and reject the unsafe subset
-with a clear error rather than miscompile it. Value-carrying `catch` blocks (which lower to
-`UpsilonNode` / `PhiCNode`) are not yet supported even when safe, and are rejected too; see
-the follow-up tracked alongside issue #194.
-
-Detection works directly on the `BBCode`, which represents every `enter` (`Core.EnterNode`
-on Julia 1.11+, `Expr(:enter)` on Julia 1.10) uniformly as an `IDEnterNode` and
-already carries the exception (catch) edges in its CFG. We run a forward data-flow pass over
-the blocks tracking how many exception-handler frames are live; a `produce` (or a call which
-might `produce`) reached while at least one frame is live is unsafe. This is version-
-agnostic and handles `try` / `catch` inside loops, unlike `Core.Compiler.compute_trycatch`
-whose shape and handler-region marking differ across the supported Julia versions.
+`produce` must not suspend while a native handler or dynamic-scope frame is active because
+that frame does not survive the return from the underlying closure. Exception edges that
+carry SSA values through `UpsilonNode` / `PhiCNode` are also unsupported.
 """
 function assert_can_handle_control_flow(ir::BBCode)
-    # Single pass to detect the start of a `try` (`IDEnterNode`) and whether a value flows out
-    # of one (`UpsilonNode` / `PhiCNode`, which only arise from exception handling).
+    # Detect exception or dynamic-scope regions and catch-carried SSA values.
     has_enter = false
     has_value_carrying = false
     for blk in ir.blocks, inst in blk.insts
@@ -206,17 +171,12 @@ function assert_can_handle_control_flow(ir::BBCode)
     # No exception-handling control flow at all (the common case).
     has_enter || return nothing
 
-    # Before Julia 1.12 the compiler passes we run over the derived IR (constant propagation,
-    # inlining, codegen) do not reliably handle exception-handling nodes -- depending on the
-    # control-flow shape they either error or miscompile to a crash. Rather than risk that,
-    # reject `try` / `catch` outright on those versions with a clear message. From 1.12 the
-    # compiler handles these nodes and the safe subset below is supported.
+    # Before Julia 1.12, later compiler passes may error or crash on these nodes.
     @static if VERSION < v"1.12-"
-        throw(ArgumentError(_TRY_CATCH_VERSION_MSG))
+        throw(ArgumentError(_REGION_VERSION_MSG))
     end
 
-    # Not-yet-supported case: a value defined in a `try` / `catch` and used afterwards lowers
-    # to `UpsilonNode` / `PhiCNode`, which the transformation does not yet handle.
+    # The transform does not yet handle SSA values carried into a catch handler.
     has_value_carrying && throw(ArgumentError(_VALUE_CARRYING_CATCH_MSG))
 
     # Unsafe case: a `produce` (or a call which might `produce`) which can run while an
@@ -240,29 +200,24 @@ function assert_can_handle_control_flow(ir::BBCode)
     return nothing
 end
 
-# Number of exception-handler frames opened (`enter`) minus closed (`leave` /
-# `:pop_exception`) by `stmt`, applied to a running `depth` (clamped at zero).
-function _apply_handler_delta(depth::Int, @nospecialize(stmt))
-    stmt isa IDEnterNode && return depth + 1
+# Change in active exception or dynamic-scope frames caused by `stmt`.
+function _handler_delta(@nospecialize(stmt))
+    stmt isa IDEnterNode && return 1
     if Meta.isexpr(stmt, :leave)
-        # On Julia 1.12+ (the only versions on which this data-flow runs -- earlier versions
-        # reject `try` / `catch` before reaching here) a `:leave` lists one enter token per
-        # frame it closes, so the number of frames closed is the token count. The integer
-        # form `Expr(:leave, n)` is the older lowering and is handled defensively only.
         n = if length(stmt.args) == 1 && stmt.args[1] isa Integer
             Int(stmt.args[1])
         else
             count(a -> a !== nothing, stmt.args)
         end
-        return max(depth - n, 0)
+        return -n
     end
-    Meta.isexpr(stmt, :pop_exception) && return max(depth - 1, 0)
-    return depth
+    Meta.isexpr(stmt, :pop_exception) && return -1
+    return 0
 end
 
-# Forward data-flow: the number of handler frames live on entry to each block. At a join we
-# take the maximum over predecessors -- structured exception handling keeps the depth equal
-# across merging paths, and the maximum is the conservative (never-under-count) choice.
+_apply_handler_delta(depth::Int, @nospecialize(stmt)) = max(depth + _handler_delta(stmt), 0)
+
+# Forward data-flow for the number of active frames on entry to each block.
 function _handler_depth_on_entry(ir::BBCode)
     preds = compute_all_predecessors(ir)
     depth_in = Dict{ID,Int}(blk.id => 0 for blk in ir.blocks)
@@ -283,42 +238,48 @@ function _handler_depth_on_entry(ir::BBCode)
             end
         end
     end
+    _assert_handler_depths(ir, preds, depth_in, depth_out)
     return depth_in
 end
 
+function _assert_handler_depths(ir::BBCode, preds, depth_in, depth_out)
+    for blk in ir.blocks
+        incoming = [depth_out[p] for p in preds[blk.id]]
+        @assert isempty(incoming) || all(==(first(incoming)), incoming) "mismatched handler depths"
+
+        depth = depth_in[blk.id]
+        for inst in blk.insts
+            depth += _handler_delta(inst.stmt)
+            @assert depth >= 0 "handler depth underflow"
+        end
+        @assert depth == depth_out[blk.id]
+    end
+    return nothing
+end
+
 const _PRODUCE_IN_HANDLER_MSG = """
-    `TapedTask` does not support a `produce` inside a `try` / `catch` / `finally` block \
-    (including a `produce` in the `try` body or in the `catch` before the block finishes). \
-    A `produce` suspends the task, but the exception-handler frame set up by the `try` \
-    cannot be restored when the task is resumed, so this cannot be reproduced faithfully. \
-    Move the `produce` outside the `try` / `catch` block (for example, by capturing a value \
-    inside the block and calling `produce` after it). See \
+    `TapedTask` does not support `produce` while an exception handler or dynamic scope is \
+    active. This includes `produce` in a `try`, `catch`, or `finally` body and in a \
+    `Base.ScopedValues.@with` body. These frames cannot be restored after `produce` suspends \
+    the task. Move `produce` after the enclosing region, capturing its result first if \
+    necessary. See \
     https://github.com/TuringLang/Libtask.jl/issues/194 for details."""
 
 const _VALUE_CARRYING_CATCH_MSG = """
-    `TapedTask` does not yet support a `try` / `catch` / `finally` block that defines a \
-    value used after the block (such code lowers to `UpsilonNode` / `PhiCNode` IR nodes). \
-    `try` / `catch` blocks which do not feed a value into later code are supported. See \
+    `TapedTask` does not yet support exception regions that lower to `UpsilonNode` / \
+    `PhiCNode`, which Julia uses to carry SSA values into catch handlers. See \
     https://github.com/TuringLang/Libtask.jl/issues/194 for details."""
 
-const _TRY_CATCH_VERSION_MSG = """
-    `TapedTask` only supports functions containing `try` / `catch` / `finally` blocks on \
-    Julia 1.12 or later; the Julia compiler does not reliably handle exception-handling IR \
-    in the derived task on earlier versions. Upgrade to Julia 1.12+, or rewrite the function \
-    to avoid `try` / `catch` (for example, by using explicit conditional checks). See \
+const _REGION_VERSION_MSG = """
+    `TapedTask` only supports exception-handling and dynamically scoped regions on Julia \
+    1.12 or later; the Julia compiler does not reliably handle their IR in the derived task \
+    on earlier versions. Upgrade to Julia 1.12+, or rewrite the function to avoid `try` / \
+    `catch` / `finally` and `Base.ScopedValues.@with`. See \
     https://github.com/TuringLang/Libtask.jl/issues/194 for details."""
-
-# `true` for statements which Julia's IR verifier treats as block-terminating but which
-# `BBCode` does not model as `Terminator`s, namely `IDEnterNode` (the start of a `try`) and
-# `Expr(:leave)` (the normal exit from a `try`). Both must remain the final statement of
-# their block, falling through to the next block (an `enter` additionally branches to its
-# catch block). We therefore neither append a `GotoNode` after them nor read their operands
-# from `Ref`s.
-function ends_block_implicitly(@nospecialize(stmt))
-    return stmt isa IDEnterNode || Meta.isexpr(stmt, :leave)
-end
 
 function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
+    assert_can_handle_control_flow(ir)
+
     # The location from which all state can be retrieved. Since we're using `OpaqueClosure`s
     # to implement `TapedTask`s, this appears via the first argument.
     refs_id = Argument(1)
@@ -368,14 +329,8 @@ function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
     # necessary, but simplifies later stages of the pipeline, as discussed variously below.
     for (n, block) in enumerate(ir.blocks)
         if terminator(block) === nothing
-            # A block ending in an `IDEnterNode` or `:leave` is left as-is: Julia's IR
-            # verifier treats both as block-terminating, so they must remain the final
-            # statement of their block (each with an implicit fall-through edge to the next
-            # block; an `enter` additionally has its catch edge). We must not append a
-            # `GotoNode` after them. Such a block always falls through to post-`try` code, so
-            # it is never the structurally-final block; assert that so any future change which
-            # broke the invariant fails loudly here rather than silently dropping the edge.
-            if !isempty(block.insts) && ends_block_implicitly(block.insts[end].stmt)
+            # `enter` and `:leave` terminate their blocks with an implicit fallthrough.
+            if !isempty(block.insts) && is_implicit_terminator(block.insts[end].stmt)
                 @assert n < length(ir.blocks) "`enter` / `:leave` in the final basic block"
                 continue
             end
@@ -453,9 +408,7 @@ function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
     # 2. Construct a map between the ID of each block and the ID associated to its split.
     top_split_id_map = Dict{ID,ID}(b.id => x[1] for (b, x) in zip(ir.blocks, all_split_ids))
 
-    # 3. Update all `GotoNode`s, `GotoIfNot`s, and `IDEnterNode` catch edges to refer to
-    #   these new names. An `enter`'s catch edge points at the catch block, which must be
-    #   re-pointed at that block's top split if it was split (a no-op when it was not).
+    # 3. Update branch destinations to refer to the top split of each block.
     for block in ir.blocks
         t = terminator(block)
         if t isa IDGotoNode
@@ -682,11 +635,7 @@ function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
                 elseif Meta.isexpr(stmt, :loopinfo)
                     push!(inst_pairs, (id, inst))
                 elseif Meta.isexpr(stmt, :pop_exception)
-                    # Pops the exception stack at the end of a `catch`. Its token argument is
-                    # the SSA produced by the corresponding `enter`; it is left as a direct
-                    # reference rather than read from a `Ref`. (An `IDEnterNode` and a
-                    # `:leave` are always block-terminating, so they are handled in the
-                    # terminator branch below rather than here.)
+                    # The matching `enter` executes within this closure invocation.
                     push!(inst_pairs, (id, inst))
                 else
                     throw(error("Unhandled stmt $stmt of type $(typeof(stmt))"))
@@ -739,11 +688,7 @@ function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
                 elseif stmt isa IDGotoNode
                     push!(inst_pairs, (id, inst))
                 elseif stmt isa IDEnterNode
-                    # The `enter` terminates its block with an implicit fall-through to the
-                    # next block plus a catch edge (encoded in the `IDEnterNode` itself). It
-                    # must remain the final statement of the block, so we emit it without
-                    # appending a `GotoNode`; the fall-through is provided by block layout.
-                    # If the enter carries a `scope` that is an SSA, restore it from storage.
+                    # Restore an SSA-valued scope before entering it.
                     if isdefined(stmt, :scope) && stmt.scope isa ID
                         ref_ind = ssa_id_to_ref_index_map[stmt.scope]
                         scope_id = ID()
@@ -757,11 +702,6 @@ function derive_copyable_task_ir(ir::BBCode)::Tuple{BBCode,Tuple,Vector{Any}}
                         push!(inst_pairs, (id, inst))
                     end
                 elseif Meta.isexpr(stmt, :leave)
-                    # The normal exit from a `try`. Like `enter`, it terminates its block (it
-                    # must be the block's final statement) and falls through to the next block
-                    # by layout, so we emit it without appending a `GotoNode`. Its token
-                    # operand is the SSA produced by the corresponding `enter` and is left as a
-                    # direct reference.
                     push!(inst_pairs, (id, inst))
                 else
                     error("Unexpected terminator $stmt")

--- a/test/copyable_task.jl
+++ b/test/copyable_task.jl
@@ -6,6 +6,118 @@ using Test
 # Used later.
 __global_a = 1.0
 
+# Functions exercising `try` / `catch` support (#194). Defined at module scope (rather than
+# inside the testset) so they are lowered like ordinary top-level functions -- a nested
+# closure can capture variables in a way that changes the exception IR (e.g. introducing
+# `UpsilonNode` / `PhiCNode`), which would not reflect normal usage.
+@noinline _tc_mayfail() = error("boom")
+@noinline _tc_maybe(i) = i == 999 ? error("x") : i
+@noinline _tc_risky(y) = y > 0 ? y * 2 : error("neg")
+
+# produce outside the handler extent -- supported on 1.12+.
+function tc_safe()
+    produce(0)
+    try
+        _tc_mayfail()
+    catch
+    end
+    produce(3)
+    return nothing
+end
+# the exception is genuinely caught (else `_tc_mayfail` would escape the task).
+function tc_caught()
+    ok = false
+    try
+        _tc_mayfail()
+    catch
+        ok = true
+    end
+    produce(ok)
+    return nothing
+end
+# try/catch inside a producing loop: exercises a `:leave` (normal try exit) followed by a
+# back-edge, which must keep `:leave` as the block terminator.
+function tc_loop()
+    for i in 1:3
+        y = 0
+        try
+            y = _tc_maybe(i)
+        catch
+            y = -1
+        end
+        produce(y)
+    end
+    return nothing
+end
+# a value defined in the try/catch and consumed afterwards which lowers to a plain `PhiNode`
+# (not `PhiCNode`): supported, unlike the `UpsilonNode` / `PhiCNode` case.
+function tc_phi(y)
+    local x
+    try
+        x = _tc_risky(y)
+    catch
+        x = -1.0
+    end
+    produce(x + 1)
+    return nothing
+end
+# unsafe: produce inside the try body (the issue's MWE).
+function tc_in_try()
+    try
+        produce(1)
+        error("")
+    catch
+        produce(2)
+    end
+    return nothing
+end
+# unsafe: produce inside the catch.
+function tc_in_catch()
+    try
+        _tc_mayfail()
+    catch
+        produce(2)
+    end
+    return nothing
+end
+# not yet supported: a value defined in the try/catch and used afterwards lowers to
+# `UpsilonNode` / `PhiCNode`.
+function tc_value(x)
+    y = 0.0
+    try
+        x > 0 && error("b")
+        y = x
+    catch
+        y = 2x
+    end
+    produce(y)
+    return nothing
+end
+
+# A `try` / `catch` inside a `Base.ScopedValues.@with` body produces a scope-only `enter`
+# (`Core.EnterNode` with `catch_dest == 0`); this must not crash IR construction (#194).
+@static if isdefined(Base, :ScopedValues)
+    const TC_SCOPED = Base.ScopedValues.ScopedValue(10)
+    # produce AFTER the scope block -- supported on 1.12+.
+    function tc_with_after()
+        Base.ScopedValues.@with TC_SCOPED => 5 begin
+            try
+                _tc_mayfail()
+            catch
+            end
+        end
+        produce(TC_SCOPED[])
+        return nothing
+    end
+    # produce INSIDE the scope -- unsafe (would suspend with the scope frame live).
+    function tc_with_inside()
+        Base.ScopedValues.@with TC_SCOPED => 5 begin
+            produce(TC_SCOPED[])
+        end
+        return nothing
+    end
+end
+
 @testset "copyable_task" begin
     @testset "get_taped_globals outside of a task" begin
         # This testset must come first because subsequent calls to get_taped_globals /
@@ -192,6 +304,112 @@ __global_a = 1.0
             f_ambig(x, y::Int) = produce(y)
             @test_throws ArgumentError TapedTask(nothing, f_ambig, 1, 1)
             @test_throws "Failed to generate IR" TapedTask(nothing, f_ambig, 1, 1)
+        end
+    end
+
+    # try / catch / finally support (#194). The supported ("safe") subset is any try / catch
+    # whose handler is set up and torn down within a single `consume` -- i.e. no `produce`
+    # suspends while a handler is active. Cases where a `produce` could suspend inside a
+    # handler, or where the block feeds a value into later code (UpsilonNode / PhiCNode), are
+    # rejected with an informative error rather than miscompiled. Support requires the Julia
+    # 1.12+ compiler to handle exception-handling IR in the derived task; on earlier versions
+    # any `try` / `catch` that survives into the IR is rejected with a clear message.
+    @testset "try/catch (#194)" begin
+        @static if VERSION >= v"1.12-"
+            # Safe cases run through the `Testcase` driver, which also copies the task after
+            # every iteration and checks each copy resumes to the same remaining results --
+            # exercising the copy/resume contract across the exception regions.
+            Libtask.TestUtils.Testcase(
+                "trycatch: produce outside handler extent",
+                nothing,
+                (tc_safe,),
+                nothing,
+                [0, 3],
+                Libtask.TestUtils.none,
+            )()
+            Libtask.TestUtils.Testcase(
+                "trycatch: exception is genuinely caught",
+                nothing,
+                (tc_caught,),
+                nothing,
+                [true],
+                Libtask.TestUtils.none,
+            )()
+            Libtask.TestUtils.Testcase(
+                "trycatch: inside a producing loop",
+                nothing,
+                (tc_loop,),
+                nothing,
+                [1, 2, 3],
+                Libtask.TestUtils.none,
+            )()
+            Libtask.TestUtils.Testcase(
+                "trycatch: PhiNode-carried catch value (caught)",
+                nothing,
+                (tc_phi, -1.0),
+                nothing,
+                [0.0],
+                Libtask.TestUtils.none,
+            )()
+            Libtask.TestUtils.Testcase(
+                "trycatch: PhiNode-carried catch value (not caught)",
+                nothing,
+                (tc_phi, 4.0),
+                nothing,
+                [9.0],
+                Libtask.TestUtils.none,
+            )()
+
+            @testset "unsafe: produce inside try body (issue MWE)" begin
+                @test_throws ArgumentError TapedTask(nothing, tc_in_try)
+                @test_throws "does not support a `produce` inside" TapedTask(
+                    nothing, tc_in_try
+                )
+            end
+
+            @testset "unsafe: produce inside catch" begin
+                @test_throws ArgumentError TapedTask(nothing, tc_in_catch)
+                @test_throws "does not support a `produce` inside" TapedTask(
+                    nothing, tc_in_catch
+                )
+            end
+
+            @testset "not yet supported: value-carrying catch" begin
+                @test_throws ArgumentError TapedTask(nothing, tc_value, 1.0)
+                @test_throws "does not yet support" TapedTask(nothing, tc_value, 1.0)
+            end
+
+            @static if isdefined(Base, :ScopedValues)
+                @testset "scope-only enter (@with): produce after scope" begin
+                    # `TC_SCOPED[]` is read outside the scope, so it is the default value.
+                    @test collect(TapedTask(nothing, tc_with_after)) == [10]
+                end
+                @testset "scope-only enter (@with): produce inside scope is unsafe" begin
+                    @test_throws "does not support a `produce` inside" TapedTask(
+                        nothing, tc_with_inside
+                    )
+                end
+            end
+        else
+            @testset "try/catch rejected before Julia 1.12" begin
+                for f in (tc_safe, tc_caught, tc_loop, tc_in_try, tc_in_catch)
+                    @test_throws ArgumentError TapedTask(nothing, f)
+                    @test_throws "only supports functions containing `try`" TapedTask(
+                        nothing, f
+                    )
+                end
+                @test_throws ArgumentError TapedTask(nothing, tc_value, 1.0)
+                @test_throws "only supports functions containing `try`" TapedTask(
+                    nothing, tc_value, 1.0
+                )
+                # A scope-only `enter` from `@with` must give the clean version error here,
+                # not crash IR construction with a `KeyError` (#194).
+                @static if isdefined(Base, :ScopedValues)
+                    @test_throws "only supports functions containing `try`" TapedTask(
+                        nothing, tc_with_after
+                    )
+                end
+            end
         end
     end
 

--- a/test/copyable_task.jl
+++ b/test/copyable_task.jl
@@ -6,13 +6,21 @@ using Test
 # Used later.
 __global_a = 1.0
 
-# Functions exercising `try` / `catch` support (#194). Defined at module scope (rather than
+# Functions exercising exception-region support (#194). Defined at module scope (rather than
 # inside the testset) so they are lowered like ordinary top-level functions -- a nested
 # closure can capture variables in a way that changes the exception IR (e.g. introducing
 # `UpsilonNode` / `PhiCNode`), which would not reflect normal usage.
 @noinline _tc_mayfail() = error("boom")
 @noinline _tc_maybe(i) = i == 999 ? error("x") : i
 @noinline _tc_risky(y) = y > 0 ? y * 2 : error("neg")
+const TC_FINALLY_EVENTS = Symbol[]
+@noinline _tc_record_cleanup() = push!(TC_FINALLY_EVENTS, :cleanup)
+
+@noinline function _tc_produce_then_throw()
+    produce(1)
+    return error("boom")
+end
+Libtask.@might_produce _tc_produce_then_throw
 
 # produce outside the handler extent -- supported on 1.12+.
 function tc_safe()
@@ -22,17 +30,6 @@ function tc_safe()
     catch
     end
     produce(3)
-    return nothing
-end
-# the exception is genuinely caught (else `_tc_mayfail` would escape the task).
-function tc_caught()
-    ok = false
-    try
-        _tc_mayfail()
-    catch
-        ok = true
-    end
-    produce(ok)
     return nothing
 end
 # try/catch inside a producing loop: exercises a `:leave` (normal try exit) followed by a
@@ -49,8 +46,7 @@ function tc_loop()
     end
     return nothing
 end
-# a value defined in the try/catch and consumed afterwards which lowers to a plain `PhiNode`
-# (not `PhiCNode`): supported, unlike the `UpsilonNode` / `PhiCNode` case.
+# Values selected after normal and caught paths use an ordinary `PhiNode` and are supported.
 function tc_phi(y)
     local x
     try
@@ -59,6 +55,29 @@ function tc_phi(y)
         x = -1.0
     end
     produce(x + 1)
+    return nothing
+end
+function tc_finally(should_throw)
+    try
+        should_throw && _tc_mayfail()
+    finally
+        _tc_record_cleanup()
+    end
+    produce(4)
+    return nothing
+end
+function tc_nested_rethrow()
+    caught = false
+    try
+        try
+            _tc_mayfail()
+        catch
+            rethrow()
+        end
+    catch
+        caught = true
+    end
+    produce(caught)
     return nothing
 end
 # unsafe: produce inside the try body (the issue's MWE).
@@ -71,6 +90,14 @@ function tc_in_try()
     end
     return nothing
 end
+# unsafe: an annotated nested call can produce and then throw inside the try body.
+function tc_indirect_in_try()
+    try
+        _tc_produce_then_throw()
+    catch
+    end
+    return nothing
+end
 # unsafe: produce inside the catch.
 function tc_in_catch()
     try
@@ -80,9 +107,16 @@ function tc_in_catch()
     end
     return nothing
 end
-# not yet supported: a value defined in the try/catch and used afterwards lowers to
-# `UpsilonNode` / `PhiCNode`.
-function tc_value(x)
+function tc_in_finally(i)
+    try
+        _tc_maybe(i)
+    finally
+        produce(2)
+    end
+    return nothing
+end
+# Reading `x` in the catch carries it across the exceptional edge via Upsilon/PhiC nodes.
+function tc_phic(x)
     y = 0.0
     try
         x > 0 && error("b")
@@ -94,17 +128,13 @@ function tc_value(x)
     return nothing
 end
 
-# A `try` / `catch` inside a `Base.ScopedValues.@with` body produces a scope-only `enter`
-# (`Core.EnterNode` with `catch_dest == 0`); this must not crash IR construction (#194).
+# `Base.ScopedValues.@with` produces a scope-only `enter` (`Core.EnterNode` with
+# `catch_dest == 0`); this must not crash IR construction (#194).
 @static if isdefined(Base, :ScopedValues)
     const TC_SCOPED = Base.ScopedValues.ScopedValue(10)
-    # produce AFTER the scope block -- supported on 1.12+.
     function tc_with_after()
         Base.ScopedValues.@with TC_SCOPED => 5 begin
-            try
-                _tc_mayfail()
-            catch
-            end
+            _tc_maybe(1)
         end
         produce(TC_SCOPED[])
         return nothing
@@ -307,14 +337,7 @@ end
         end
     end
 
-    # try / catch / finally support (#194). The supported ("safe") subset is any try / catch
-    # whose handler is set up and torn down within a single `consume` -- i.e. no `produce`
-    # suspends while a handler is active. Cases where a `produce` could suspend inside a
-    # handler, or where the block feeds a value into later code (UpsilonNode / PhiCNode), are
-    # rejected with an informative error rather than miscompiled. Support requires the Julia
-    # 1.12+ compiler to handle exception-handling IR in the derived task; on earlier versions
-    # any `try` / `catch` that survives into the IR is rejected with a clear message.
-    @testset "try/catch (#194)" begin
+    @testset "exception regions (#194)" begin
         @static if VERSION >= v"1.12-"
             # Safe cases run through the `Testcase` driver, which also copies the task after
             # every iteration and checks each copy resumes to the same remaining results --
@@ -325,14 +348,6 @@ end
                 (tc_safe,),
                 nothing,
                 [0, 3],
-                Libtask.TestUtils.none,
-            )()
-            Libtask.TestUtils.Testcase(
-                "trycatch: exception is genuinely caught",
-                nothing,
-                (tc_caught,),
-                nothing,
-                [true],
                 Libtask.TestUtils.none,
             )()
             Libtask.TestUtils.Testcase(
@@ -359,24 +374,55 @@ end
                 [9.0],
                 Libtask.TestUtils.none,
             )()
+            Libtask.TestUtils.Testcase(
+                "trycatch: nested catch and rethrow",
+                nothing,
+                (tc_nested_rethrow,),
+                nothing,
+                [true],
+                Libtask.TestUtils.none,
+            )()
+
+            @testset "finally runs on normal and exceptional exits" begin
+                empty!(TC_FINALLY_EVENTS)
+                @test collect(TapedTask(nothing, tc_finally, false)) == [4]
+                @test TC_FINALLY_EVENTS == [:cleanup]
+
+                empty!(TC_FINALLY_EVENTS)
+                task = TapedTask(nothing, tc_finally, true)
+                @test_throws ErrorException collect(task)
+                @test TC_FINALLY_EVENTS == [:cleanup]
+            end
 
             @testset "unsafe: produce inside try body (issue MWE)" begin
                 @test_throws ArgumentError TapedTask(nothing, tc_in_try)
-                @test_throws "does not support a `produce` inside" TapedTask(
+                @test_throws "does not support `produce` while" TapedTask(
                     nothing, tc_in_try
                 )
             end
 
             @testset "unsafe: produce inside catch" begin
                 @test_throws ArgumentError TapedTask(nothing, tc_in_catch)
-                @test_throws "does not support a `produce` inside" TapedTask(
+                @test_throws "does not support `produce` while" TapedTask(
                     nothing, tc_in_catch
                 )
             end
 
-            @testset "not yet supported: value-carrying catch" begin
-                @test_throws ArgumentError TapedTask(nothing, tc_value, 1.0)
-                @test_throws "does not yet support" TapedTask(nothing, tc_value, 1.0)
+            @testset "unsafe: produce inside finally" begin
+                @test_throws "does not support `produce` while" TapedTask(
+                    nothing, tc_in_finally, 1
+                )
+            end
+
+            @testset "unsafe: annotated producing call inside try" begin
+                @test_throws "does not support `produce` while" TapedTask(
+                    nothing, tc_indirect_in_try
+                )
+            end
+
+            @testset "unsupported: SSA value carried into catch" begin
+                @test_throws ArgumentError TapedTask(nothing, tc_phic, 1.0)
+                @test_throws "carry SSA values into catch" TapedTask(nothing, tc_phic, 1.0)
             end
 
             @static if isdefined(Base, :ScopedValues)
@@ -385,27 +431,20 @@ end
                     @test collect(TapedTask(nothing, tc_with_after)) == [10]
                 end
                 @testset "scope-only enter (@with): produce inside scope is unsafe" begin
-                    @test_throws "does not support a `produce` inside" TapedTask(
+                    @test_throws "does not support `produce` while" TapedTask(
                         nothing, tc_with_inside
                     )
                 end
             end
         else
-            @testset "try/catch rejected before Julia 1.12" begin
-                for f in (tc_safe, tc_caught, tc_loop, tc_in_try, tc_in_catch)
-                    @test_throws ArgumentError TapedTask(nothing, f)
-                    @test_throws "only supports functions containing `try`" TapedTask(
-                        nothing, f
-                    )
-                end
-                @test_throws ArgumentError TapedTask(nothing, tc_value, 1.0)
-                @test_throws "only supports functions containing `try`" TapedTask(
-                    nothing, tc_value, 1.0
+            @testset "exception regions rejected before Julia 1.12" begin
+                @test_throws ArgumentError TapedTask(nothing, tc_safe)
+                @test_throws "only supports exception-handling" TapedTask(nothing, tc_safe)
+                @test_throws "only supports exception-handling" TapedTask(
+                    nothing, tc_finally, false
                 )
-                # A scope-only `enter` from `@with` must give the clean version error here,
-                # not crash IR construction with a `KeyError` (#194).
                 @static if isdefined(Base, :ScopedValues)
-                    @test_throws "only supports functions containing `try`" TapedTask(
+                    @test_throws "only supports exception-handling" TapedTask(
                         nothing, tc_with_after
                     )
                 end


### PR DESCRIPTION
On Julia 1.12+, `TapedTask` can now transform `try`/`catch`/`finally` and dynamically scoped regions when they complete within one `consume`. Previously, surviving exception-region IR prevented construction of the copyable task.

For example, Turing’s particle samplers can now run a model with deterministic cleanup before sampling:

```julia
using StableRNGs, Turing

const cleanups = Ref(0)

@model function model(y)
    try
        y > 0 || error("invalid observation")
    finally
        cleanups[] += 1
    end

    x ~ Normal()
    return y ~ Normal(x)
end

sample(StableRNG(42), model(2.0), SMC(), 20)
```

The transform now represents exception edges explicitly and tracks active handler depth. It rejects `produce` while a handler or dynamic scope is active because that native frame cannot be restored after suspension. Unsupported `UpsilonNode`/`PhiCNode` regions and exception regions before Julia 1.12 fail locally with an `ArgumentError`.

Tested on Julia 1.10, 1.11, and 1.12, plus Turing 0.47.

Fix https://github.com/TuringLang/Libtask.jl/issues/194